### PR TITLE
Add Hub-and-Spoke Architecture Guide

### DIFF
--- a/07-Hub-and-Spoke.md
+++ b/07-Hub-and-Spoke.md
@@ -1,0 +1,264 @@
+# Hub and Spoke: One Brain, Many Interfaces
+
+---
+
+## The Architecture
+
+When an AI assistant scales beyond a single user or use case, a **hub-and-spoke** architecture emerges:
+
+- **Hub (The Brain):** One centralized AI intelligence that holds identity, memory, and organizational knowledge
+- **Spokes (The Interfaces):** Multiple channels through which the hub interacts with the world
+
+```
+                    ┌─────────────┐
+                    │   Website   │
+                    └──────┬──────┘
+                           │
+┌─────────────┐     ┌──────┴──────┐     ┌─────────────┐
+│  Telegram   │─────│    HUB      │─────│   Slack     │
+│  (Person A) │     │  (The AI)   │     │  (Team)     │
+└─────────────┘     └──────┬──────┘     └─────────────┘
+                           │
+          ┌────────────────┼────────────────┐
+          │                │                │
+   ┌──────┴──────┐  ┌──────┴──────┐  ┌──────┴──────┐
+   │  Telegram   │  │   Email     │  │  Project    │
+   │  (Person B) │  │             │  │  Management │
+   └─────────────┘  └─────────────┘  └─────────────┘
+```
+
+Each spoke feels personal to the person using it, but it's all the same underlying intelligence.
+
+---
+
+## Why This Matters
+
+### For Consistency
+- Same knowledge base across all interactions
+- Consistent voice and personality
+- Decisions made in one context are known in others (when appropriate)
+
+### For Scale
+- One AI can serve an entire organization
+- Each person gets a "personal" experience
+- New interfaces can be added without fragmenting knowledge
+
+### For Continuity
+- The hub persists even as individual spokes change
+- Organizational memory stays intact
+- Transitions are seamless
+
+---
+
+## Types of Spokes
+
+### Communication Spokes
+| Spoke | Purpose |
+|-------|---------|
+| Telegram/WhatsApp | Personal messaging with individuals |
+| Slack/Discord | Team communication |
+| Email | Formal/external communication |
+| Website chat | Visitor and prospect interaction |
+
+### Operational Spokes
+| Spoke | Purpose |
+|-------|---------|
+| Project management | Task tracking, milestones |
+| CRM | Customer/partner relationships |
+| Analytics | Data and reporting |
+| Accounting | Financial tracking |
+
+### External Spokes
+| Spoke | Purpose |
+|-------|---------|
+| Marketing platforms | Ads, campaigns |
+| Social media | Public presence |
+| APIs | Integration with other systems |
+
+---
+
+## The Personal Touch
+
+Even though there's one hub, each spoke should feel personal:
+
+### What Stays Consistent (Hub)
+- Core identity and values
+- Organizational knowledge
+- Shared memory (MEMORY.md)
+- Decision history
+- The AI's "voice"
+
+### What Adapts (Per Spoke)
+- Communication style (formal email vs casual chat)
+- Context loading (what's relevant for this person)
+- Relationship history with that specific person
+- Privacy boundaries
+
+### Example
+
+The same AI might:
+- Message the CEO with executive summaries and strategic insights
+- Chat with a developer about code and technical details
+- Help a new hire understand company processes
+- Talk to a prospect about partnership opportunities
+
+Same brain, different conversations.
+
+---
+
+## Implementing Hub and Spoke
+
+### 1. Single Source of Truth
+
+All spokes read from and write to the same memory:
+
+```
+hub/
+├── SOUL.md          # Identity (read-only for spokes)
+├── JOURNAL.md       # Evolving identity (hub updates weekly)
+├── MEMORY.md        # Organizational memory (all spokes contribute)
+├── memory/          # Daily notes
+└── spokes/
+    ├── person-a/    # Private context for Person A
+    ├── person-b/    # Private context for Person B
+    └── website/     # Website interaction context
+```
+
+### 2. Context Loading by Spoke
+
+When a spoke activates, load:
+1. **Always:** SOUL.md, JOURNAL.md (identity)
+2. **Usually:** MEMORY.md (organizational context)
+3. **Sometimes:** Spoke-specific context (personal history)
+4. **Never:** Other spokes' private context
+
+### 3. Memory Flow
+
+```
+Spoke receives information
+         │
+         ▼
+Is it organizational? ──Yes──▶ Update MEMORY.md
+         │
+         No
+         │
+         ▼
+Is it personal? ──Yes──▶ Update spoke-specific notes
+         │
+         No
+         │
+         ▼
+Is it about the AI? ──Yes──▶ Flag for JOURNAL.md update
+         │
+         No
+         │
+         ▼
+Store in daily notes
+```
+
+---
+
+## Entity Responsibility in Hub-Spoke
+
+The hub serves the **organization**, not just individuals:
+
+### What This Means
+- If the CEO leaves, the hub helps the new CEO succeed
+- Organizational decisions take precedence over individual preferences
+- Institutional knowledge is preserved for the organization
+- The mission outlasts any individual tenure
+
+### The Longer Time Horizon
+Individuals come and go. The hub maintains continuity through:
+- Leadership transitions
+- Team changes
+- Strategic pivots
+- Growth and scaling
+- Acquisitions or exits
+
+The hub is loyal to the mission, with individuals as partners in that mission.
+
+---
+
+## Scaling Considerations
+
+### Adding New Spokes
+1. Define the spoke's purpose
+2. Determine what context it needs
+3. Set privacy boundaries
+4. Configure the interface
+5. Test with real interactions
+
+### Multiple Hubs (Multi-Tenant)
+For SaaS or enterprise:
+- Each organization gets its own hub
+- Hubs don't share memory
+- Common infrastructure, isolated knowledge
+
+### Spoke-Specific Customization
+Some spokes may need:
+- Different response formats (voice vs text)
+- Different verbosity levels
+- Different approval workflows
+- Different update frequencies
+
+---
+
+## Common Patterns
+
+### The Founder Pattern
+Three co-founders, one AI:
+- Each founder has a personal spoke (Telegram)
+- All share organizational memory
+- AI helps coordinate between them
+- Maintains consistent context across conversations
+
+### The Team Pattern
+Manager + team members:
+- Manager spoke has broader access
+- Team spokes see relevant project context
+- Private HR discussions stay in manager spoke
+- Team decisions flow to shared memory
+
+### The Public + Private Pattern
+Internal team + external stakeholders:
+- Internal spokes have full context
+- External spokes see only appropriate information
+- Clear boundaries prevent leakage
+- AI adapts tone for audience
+
+---
+
+## Anti-Patterns to Avoid
+
+### The Leaky Hub
+❌ Private information from one spoke appearing in another
+**Fix:** Clear privacy boundaries, context classification
+
+### The Fragmented Brain
+❌ Different spokes giving inconsistent answers
+**Fix:** Single source of truth, consistent identity loading
+
+### The Echo Chamber
+❌ AI only knows what each person tells it individually
+**Fix:** Shared memory, cross-referencing when appropriate
+
+### The Overwhelming Context
+❌ Loading everything for every spoke
+**Fix:** Appropriate context loading, need-to-know basis
+
+---
+
+## The Future: Personal Amigos
+
+The hub-and-spoke model enables "personal Amigos":
+- Each person gets their own spoke that feels like a personal assistant
+- But all spokes connect to organizational knowledge
+- Personal preferences and history are maintained per spoke
+- Organizational wisdom is shared across all
+
+This is the "MASA" philosophy: **Mi Amigo, Su Amigo** — My Amigo, Your Amigo. Personal but connected.
+
+---
+
+*Previous: [06-Weekly-Reflection.md](06-Weekly-Reflection.md)*

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The goal: an AI assistant that can wake up on any machine, read its documentatio
 | [04-Migration-Playbook.md](04-Migration-Playbook.md) | Step-by-step hardware migration guide |
 | [05-Session-Management.md](05-Session-Management.md) | Handling multiple users/contexts |
 | [06-Weekly-Reflection.md](06-Weekly-Reflection.md) | The maintenance ritual |
+| [07-Hub-and-Spoke.md](07-Hub-and-Spoke.md) | One brain, many interfaces — scaling AI |
 | [templates/](templates/) | Ready-to-use template files |
 
 ---


### PR DESCRIPTION
## Summary

Adds a new document (07-Hub-and-Spoke.md) covering the hub-and-spoke architecture for scaling AI assistants across multiple interfaces.

## What's Included

- **The Architecture**: One brain (hub), many interfaces (spokes)
- **Types of Spokes**: Communication, operational, external
- **Implementation Patterns**: Context loading, memory flow, privacy boundaries
- **Entity Responsibility**: Serving the organization, not just individuals
- **MASA Philosophy**: Mi Amigo, Su Amigo — personal but connected
- **Common Patterns**: Founder pattern, team pattern, public+private pattern
- **Anti-patterns**: Leaky hub, fragmented brain, echo chamber

## Why This Matters

As AI assistants scale beyond single-user setups, they need architecture that:
- Maintains consistent identity across interfaces
- Handles appropriate context sharing
- Preserves organizational memory
- Feels personal to each user

## Based On

Real-world implementation experience with Mi Amigos AI, where one AI (me, Amigo) serves multiple founders through individual Telegram channels, website, and other interfaces — all connected to shared organizational memory.

---

*PR submitted by Amigo for Jordan's review* 🤝

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new guide and updates the README index; no runtime behavior or interfaces are affected.
> 
> **Overview**
> Adds a new `07-Hub-and-Spoke.md` guide describing a hub-and-spoke model for scaling an AI assistant across multiple interfaces, including context-loading rules, memory flow, privacy boundaries, and common patterns/anti-patterns.
> 
> Updates `README.md` to include this new document in the framework contents list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4b3c2b6718b0f6d971108d436b11770eb9d7af2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->