### PR TITLE
feat(guardian): Consolidator Agent with dedup, merge, and linking

### DIFF
--- a/guardian/src/__tests__/consolidator.test.ts
+++ b/guardian/src/__tests__/consolidator.test.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ExtractedMemory, ConsolidatedMemory } from '../db/schema.js';
+
+// -- Hoisted mock state --
+
+const mockState = vi.hoisted(() => ({
+  unconsolidatedMemories: [] as ExtractedMemory[],
+  consolidatedMemories: [] as ConsolidatedMemory[],
+  insertedConsolidated: [] as Record<string, unknown>[],
+  updatedConsolidated: [] as { id: string; updates: Record<string, unknown> }[],
+  markedConsolidated: [] as { memoryId: string; consolidatedInto: string }[],
+  agentStateUpserts: [] as Record<string, unknown>[],
+  llmCallCount: 0,
+  llmShouldFail: false,
+  insertCounter: 0,
+}));
+
+// -- Mock LLM client --
+
+vi.mock('../llm/client.js', () => ({
+  getAnthropicClient: vi.fn(() => ({
+    messages: {
+      create: vi.fn(async () => {
+        mockState.llmCallCount++;
+        if (mockState.llmShouldFail) {
+          throw new Error('LLM API error');
+        }
+        return {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool-call-merge-001',
+              name: 'merge_memories',
+              input: {
+                merged_content:
+                  'Combined memory: both the existing and new information are preserved.',
+                topics: ['memory-decay', 'consolidation'],
+              },
+            },
+          ],
+        };
+      }),
+    },
+  })),
+  getOpenAIClient: vi.fn(),
+  resetLLMClients: vi.fn(),
+}));
+
+// -- Mock DB --
+
+vi.mock('../db/client.js', () => ({
+  getSupabaseClient: vi.fn(() => ({})),
+}));
+
+vi.mock('../db/queries.js', () => ({
+  getUnconsolidatedMemories: vi.fn(async () => {
+    return mockState.unconsolidatedMemories;
+  }),
+  getConsolidatedMemoriesWithEmbeddings: vi.fn(async () => {
+    return mockState.consolidatedMemories;
+  }),
+  markMemoryConsolidated: vi.fn(
+    async (_client: unknown, memoryId: string, consolidatedInto: string) => {
+      mockState.markedConsolidated.push({ memoryId, consolidatedInto });
+    },
+  ),
+  insertConsolidatedMemory: vi.fn(async (_client: unknown, memory: Record<string, unknown>) => {
+    mockState.insertCounter++;
+    const id = `consolidated-new-${mockState.insertCounter}`;
+    mockState.insertedConsolidated.push({ ...memory, id });
+    return { ...memory, id, version: 1, stability: 0.5, tier: 'short' };
+  }),
+  updateConsolidatedMemory: vi.fn(
+    async (_client: unknown, id: string, updates: Record<string, unknown>) => {
+      mockState.updatedConsolidated.push({ id, updates });
+      return { id, ...updates };
+    },
+  ),
+  upsertAgentState: vi.fn(async (_client: unknown, state: Record<string, unknown>) => {
+    mockState.agentStateUpserts.push(state);
+    return state;
+  }),
+}));
+
+// Import after mocks
+import { runConsolidator, cosineSimilarity } from '../agents/consolidator.js';
+
+// -- Test helpers --
+
+/** Create a fake 1536-d embedding with a specific "direction" controlled by the seed. */
+function makeEmbedding(seed: number): number[] {
+  return Array.from({ length: 1536 }, (_, i) => Math.sin(seed + i * 0.01));
+}
+
+/** Create a very similar embedding (high cosine similarity). */
+function makeSimilarEmbedding(base: number[], noise: number): number[] {
+  return base.map((v) => v + noise * 0.001);
+}
+
+function makeExtractedMemory(overrides: Partial<ExtractedMemory> = {}): ExtractedMemory {
+  return {
+    id: 'ext-001',
+    source_event_id: 'event-001',
+    contributor_id: 'contrib-001',
+    repo_id: 'leonardrknight/ai-continuity-framework',
+    content: 'Memory decay uses Ebbinghaus curves for importance scoring.',
+    content_embedding: makeEmbedding(1),
+    memory_type: 'fact',
+    topics: ['memory-decay'],
+    entities: ['ebbinghaus'],
+    importance_score: 0.7,
+    confidence_score: 0.9,
+    source_type: 'stated',
+    emotional_valence: null,
+    emotional_arousal: null,
+    access_count: 0,
+    last_accessed_at: null,
+    consolidated: false,
+    consolidated_into: null,
+    created_at: '2026-03-10T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeConsolidatedMemory(overrides: Partial<ConsolidatedMemory> = {}): ConsolidatedMemory {
+  return {
+    id: 'cons-001',
+    repo_id: 'leonardrknight/ai-continuity-framework',
+    contributor_id: 'contrib-001',
+    content: 'Memory decay uses Ebbinghaus curves.',
+    content_embedding: makeEmbedding(1),
+    memory_type: 'fact',
+    topics: ['memory-decay'],
+    importance_score: 0.6,
+    stability: 0.5,
+    related_memories: null,
+    source_memories: ['ext-prev-001'],
+    tier: 'short',
+    access_count: 0,
+    last_accessed_at: null,
+    version: 1,
+    created_at: '2026-03-09T10:00:00Z',
+    updated_at: '2026-03-09T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('cosineSimilarity', () => {
+  it('returns 1 for identical vectors', () => {
+    const v = [1, 2, 3, 4, 5];
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1.0);
+  });
+
+  it('returns 0 for orthogonal vectors', () => {
+    const a = [1, 0, 0];
+    const b = [0, 1, 0];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0.0);
+  });
+
+  it('returns -1 for opposite vectors', () => {
+    const a = [1, 2, 3];
+    const b = [-1, -2, -3];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(-1.0);
+  });
+
+  it('returns 0 for empty vectors', () => {
+    expect(cosineSimilarity([], [])).toBe(0);
+  });
+
+  it('returns 0 for mismatched lengths', () => {
+    expect(cosineSimilarity([1, 2], [1, 2, 3])).toBe(0);
+  });
+
+  it('returns 0 for zero vectors', () => {
+    expect(cosineSimilarity([0, 0, 0], [0, 0, 0])).toBe(0);
+  });
+});
+
+describe('Consolidator Agent', () => {
+  beforeEach(() => {
+    mockState.unconsolidatedMemories = [];
+    mockState.consolidatedMemories = [];
+    mockState.insertedConsolidated = [];
+    mockState.updatedConsolidated = [];
+    mockState.markedConsolidated = [];
+    mockState.agentStateUpserts = [];
+    mockState.llmCallCount = 0;
+    mockState.llmShouldFail = false;
+    mockState.insertCounter = 0;
+  });
+
+  it('returns early when no unconsolidated memories exist', async () => {
+    mockState.unconsolidatedMemories = [];
+
+    const result = await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    expect(result.memoriesProcessed).toBe(0);
+    expect(result.memoriesMerged).toBe(0);
+    expect(result.memoriesLinked).toBe(0);
+    expect(result.memoriesCreated).toBe(0);
+    expect(result.errors).toBe(0);
+    // No agent state update when nothing to process
+    expect(mockState.agentStateUpserts.length).toBe(0);
+  });
+
+  it('creates new consolidated memory when no existing memories to compare', async () => {
+    const extracted = makeExtractedMemory();
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [];
+
+    const result = await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    expect(result.memoriesProcessed).toBe(1);
+    expect(result.memoriesCreated).toBe(1);
+    expect(result.memoriesMerged).toBe(0);
+    expect(result.memoriesLinked).toBe(0);
+
+    // Verify a consolidated memory was inserted
+    expect(mockState.insertedConsolidated.length).toBe(1);
+    const inserted = mockState.insertedConsolidated[0];
+    expect(inserted.content).toBe(extracted.content);
+    expect(inserted.source_memories).toEqual([extracted.id]);
+
+    // Verify extracted memory was marked consolidated
+    expect(mockState.markedConsolidated.length).toBe(1);
+    expect(mockState.markedConsolidated[0].memoryId).toBe(extracted.id);
+  });
+
+  it('merges duplicate memories (>0.92 similarity) via LLM', async () => {
+    const baseEmbedding = makeEmbedding(1);
+    const nearDuplicateEmbedding = makeSimilarEmbedding(baseEmbedding, 0.5);
+
+    // Verify they are indeed very similar
+    const sim = cosineSimilarity(baseEmbedding, nearDuplicateEmbedding);
+    expect(sim).toBeGreaterThan(DUPLICATE_THRESHOLD);
+
+    const existing = makeConsolidatedMemory({
+      content_embedding: baseEmbedding,
+      importance_score: 0.6,
+    });
+    const extracted = makeExtractedMemory({
+      content_embedding: nearDuplicateEmbedding,
+      importance_score: 0.7,
+    });
+
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [existing];
+
+    const result = await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    expect(result.memoriesMerged).toBe(1);
+    expect(result.memoriesProcessed).toBe(1);
+    expect(mockState.llmCallCount).toBe(1);
+
+    // Verify the existing consolidated memory was updated
+    expect(mockState.updatedConsolidated.length).toBe(1);
+    const update = mockState.updatedConsolidated[0];
+    expect(update.id).toBe(existing.id);
+    expect(update.updates.content).toBe(
+      'Combined memory: both the existing and new information are preserved.',
+    );
+
+    // Verify extracted memory was marked consolidated into the existing one
+    expect(mockState.markedConsolidated[0].consolidatedInto).toBe(existing.id);
+  });
+
+  it('boosts importance by 10% on merge (takes higher, capped at 1.0)', async () => {
+    const baseEmbedding = makeEmbedding(1);
+    const nearDuplicateEmbedding = makeSimilarEmbedding(baseEmbedding, 0.5);
+
+    const existing = makeConsolidatedMemory({
+      content_embedding: baseEmbedding,
+      importance_score: 0.6,
+    });
+    const extracted = makeExtractedMemory({
+      content_embedding: nearDuplicateEmbedding,
+      importance_score: 0.7,
+    });
+
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [existing];
+
+    await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    const update = mockState.updatedConsolidated[0];
+    // Higher is 0.7, boosted by 10% = 0.77
+    expect(update.updates.importance_score).toBeCloseTo(0.77, 2);
+  });
+
+  it('caps boosted importance at 1.0', async () => {
+    const baseEmbedding = makeEmbedding(1);
+    const nearDuplicateEmbedding = makeSimilarEmbedding(baseEmbedding, 0.5);
+
+    const existing = makeConsolidatedMemory({
+      content_embedding: baseEmbedding,
+      importance_score: 0.95,
+    });
+    const extracted = makeExtractedMemory({
+      content_embedding: nearDuplicateEmbedding,
+      importance_score: 0.98,
+    });
+
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [existing];
+
+    await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    const update = mockState.updatedConsolidated[0];
+    // 0.98 * 1.1 = 1.078, capped at 1.0
+    expect(update.updates.importance_score).toBe(1.0);
+  });
+
+  it('links related memories (0.75-0.92 similarity)', async () => {
+    // Create embeddings that are similar but not duplicate
+    const baseEmbedding = makeEmbedding(1);
+    // Add more noise to push similarity into the 0.75-0.92 range
+    const relatedEmbedding = baseEmbedding.map((v, i) => v + Math.sin(i * 0.5) * 0.6);
+
+    const sim = cosineSimilarity(baseEmbedding, relatedEmbedding);
+    // Verify similarity is in the related range
+    expect(sim).toBeGreaterThanOrEqual(RELATED_THRESHOLD);
+    expect(sim).toBeLessThan(DUPLICATE_THRESHOLD);
+
+    const existing = makeConsolidatedMemory({ content_embedding: baseEmbedding });
+    const extracted = makeExtractedMemory({
+      id: 'ext-related',
+      content_embedding: relatedEmbedding,
+    });
+
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [existing];
+
+    const result = await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    expect(result.memoriesLinked).toBe(1);
+    expect(result.memoriesProcessed).toBe(1);
+
+    // A new consolidated memory is created for the extracted content
+    expect(mockState.insertedConsolidated.length).toBe(1);
+
+    // The existing consolidated memory's related_memories is updated
+    const relatedUpdate = mockState.updatedConsolidated.find((u) => u.id === existing.id);
+    expect(relatedUpdate).toBeDefined();
+    expect(relatedUpdate!.updates.related_memories).toBeDefined();
+    const relatedIds = relatedUpdate!.updates.related_memories as string[];
+    expect(relatedIds.length).toBe(1);
+
+    // No LLM call for linking (only merging uses LLM)
+    expect(mockState.llmCallCount).toBe(0);
+  });
+
+  it('creates new consolidated memory for novel content (<0.75 similarity)', async () => {
+    // Create very different embeddings
+    const baseEmbedding = makeEmbedding(1);
+    const differentEmbedding = makeEmbedding(100);
+
+    const sim = cosineSimilarity(baseEmbedding, differentEmbedding);
+    expect(sim).toBeLessThan(RELATED_THRESHOLD);
+
+    const existing = makeConsolidatedMemory({ content_embedding: baseEmbedding });
+    const extracted = makeExtractedMemory({
+      id: 'ext-novel',
+      content: 'Completely different topic about agent architecture.',
+      content_embedding: differentEmbedding,
+    });
+
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [existing];
+
+    const result = await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    expect(result.memoriesCreated).toBe(1);
+    expect(result.memoriesProcessed).toBe(1);
+    expect(result.memoriesMerged).toBe(0);
+    expect(result.memoriesLinked).toBe(0);
+
+    // New consolidated memory inserted
+    expect(mockState.insertedConsolidated.length).toBe(1);
+    expect(mockState.insertedConsolidated[0].content).toBe(
+      'Completely different topic about agent architecture.',
+    );
+  });
+
+  it('handles LLM merge failures gracefully (leaves unconsolidated for retry)', async () => {
+    mockState.llmShouldFail = true;
+
+    const baseEmbedding = makeEmbedding(1);
+    const nearDuplicateEmbedding = makeSimilarEmbedding(baseEmbedding, 0.5);
+
+    const existing = makeConsolidatedMemory({ content_embedding: baseEmbedding });
+    const extracted = makeExtractedMemory({
+      content_embedding: nearDuplicateEmbedding,
+    });
+
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [existing];
+
+    const result = await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    expect(result.errors).toBe(1);
+    expect(result.memoriesMerged).toBe(0);
+    // Memory should NOT be marked consolidated
+    expect(mockState.markedConsolidated.length).toBe(0);
+  });
+
+  it('updates agent_state after a run', async () => {
+    const extracted = makeExtractedMemory();
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [];
+
+    await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    expect(mockState.agentStateUpserts.length).toBe(1);
+    const state = mockState.agentStateUpserts[0];
+    expect(state.agent_name).toBe('consolidator');
+    expect(state.repo_id).toBe('leonardrknight/ai-continuity-framework');
+    expect(state.items_processed).toBe(1);
+    expect(state.last_run_at).toBeDefined();
+    expect(state.last_successful_at).toBeDefined();
+  });
+
+  it('creates new consolidated entries for memories without embeddings', async () => {
+    const extracted = makeExtractedMemory({
+      id: 'ext-no-embedding',
+      content_embedding: null,
+    });
+    mockState.unconsolidatedMemories = [extracted];
+    mockState.consolidatedMemories = [makeConsolidatedMemory()];
+
+    const result = await runConsolidator({} as never, 'leonardrknight/ai-continuity-framework');
+
+    expect(result.memoriesCreated).toBe(1);
+    expect(result.memoriesProcessed).toBe(1);
+    expect(result.memoriesMerged).toBe(0);
+    expect(result.memoriesLinked).toBe(0);
+
+    // Should have inserted a new consolidated memory
+    expect(mockState.insertedConsolidated.length).toBe(1);
+    expect(mockState.insertedConsolidated[0].content_embedding).toBeNull();
+  });
+});
+
+// Threshold constants used in assertions
+const DUPLICATE_THRESHOLD = 0.92;
+const RELATED_THRESHOLD = 0.75;

--- a/guardian/src/agents/consolidator.ts
+++ b/guardian/src/agents/consolidator.ts
@@ -1,0 +1,333 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getAnthropicClient } from '../llm/client.js';
+import {
+  MERGE_SYSTEM_PROMPT,
+  MERGE_TOOL_SCHEMA,
+  buildMergeUserMessage,
+  type MergedMemoryLLM,
+} from '../llm/prompts.js';
+import {
+  getUnconsolidatedMemories,
+  getConsolidatedMemoriesWithEmbeddings,
+  markMemoryConsolidated,
+  insertConsolidatedMemory,
+  updateConsolidatedMemory,
+  upsertAgentState,
+} from '../db/queries.js';
+import type {
+  ExtractedMemory,
+  ConsolidatedMemory,
+  ConsolidatedMemoryInsert,
+} from '../db/schema.js';
+
+const CONSOLIDATION_MODEL = 'claude-sonnet-4-6-20250514';
+const MAX_LLM_RETRIES = 3;
+const BATCH_SIZE = 50;
+const DUPLICATE_THRESHOLD = 0.92;
+const RELATED_THRESHOLD = 0.75;
+
+/** Result from a single consolidation run. */
+export interface ConsolidationRunResult {
+  memoriesProcessed: number;
+  memoriesMerged: number;
+  memoriesLinked: number;
+  memoriesCreated: number;
+  errors: number;
+}
+
+/**
+ * Compute cosine similarity between two vectors.
+ * Returns a value between -1 and 1 (1 = identical direction).
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+  if (denominator === 0) return 0;
+
+  return dotProduct / denominator;
+}
+
+/**
+ * Find the most similar consolidated memory for a given embedding.
+ * Returns the best match and its similarity score, or null if no matches exist.
+ */
+function findBestMatch(
+  embedding: number[],
+  consolidated: ConsolidatedMemory[],
+): { match: ConsolidatedMemory; similarity: number } | null {
+  let bestMatch: ConsolidatedMemory | null = null;
+  let bestSimilarity = -1;
+
+  for (const cm of consolidated) {
+    if (!cm.content_embedding) continue;
+    const sim = cosineSimilarity(embedding, cm.content_embedding);
+    if (sim > bestSimilarity) {
+      bestSimilarity = sim;
+      bestMatch = cm;
+    }
+  }
+
+  if (!bestMatch) return null;
+  return { match: bestMatch, similarity: bestSimilarity };
+}
+
+/**
+ * Call the LLM to merge two memory contents into one.
+ * Returns the merged content and topics, or throws on failure.
+ */
+async function callMergeLLM(existingContent: string, newContent: string): Promise<MergedMemoryLLM> {
+  const anthropic = getAnthropicClient();
+  const userMessage = buildMergeUserMessage(existingContent, newContent);
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_LLM_RETRIES; attempt++) {
+    try {
+      const response = await anthropic.messages.create({
+        model: CONSOLIDATION_MODEL,
+        max_tokens: 1024,
+        system: MERGE_SYSTEM_PROMPT,
+        tools: [MERGE_TOOL_SCHEMA],
+        tool_choice: { type: 'tool', name: 'merge_memories' },
+        messages: [{ role: 'user', content: userMessage }],
+      });
+
+      const toolBlock = response.content.find((block) => block.type === 'tool_use');
+      if (!toolBlock || toolBlock.type !== 'tool_use') {
+        throw new Error('No tool_use block in LLM response');
+      }
+
+      const input = toolBlock.input as MergedMemoryLLM;
+      return input;
+    } catch (error) {
+      lastError = error;
+      if (attempt < MAX_LLM_RETRIES - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * Math.pow(2, attempt)));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Merge an extracted memory into an existing consolidated memory.
+ * Uses LLM to synthesize content, boosts importance by 10%.
+ */
+async function mergeMemory(
+  client: SupabaseClient,
+  extracted: ExtractedMemory,
+  existing: ConsolidatedMemory,
+): Promise<void> {
+  const merged = await callMergeLLM(existing.content, extracted.content);
+
+  // Importance: take the higher of the two, boost by 10%, cap at 1.0
+  const higherImportance = Math.max(existing.importance_score, extracted.importance_score);
+  const boostedImportance = Math.min(higherImportance * 1.1, 1.0);
+
+  // Merge source_memories list
+  const sourceMemories = [...(existing.source_memories ?? []), extracted.id];
+
+  await updateConsolidatedMemory(client, existing.id, {
+    content: merged.merged_content,
+    topics: merged.topics,
+    importance_score: boostedImportance,
+    source_memories: sourceMemories,
+    content_embedding: extracted.content_embedding,
+    version: existing.version + 1,
+  });
+
+  await markMemoryConsolidated(client, extracted.id, existing.id);
+}
+
+/**
+ * Link an extracted memory as related to an existing consolidated memory.
+ */
+async function linkMemory(
+  client: SupabaseClient,
+  extracted: ExtractedMemory,
+  existing: ConsolidatedMemory,
+): Promise<string> {
+  // Create a new consolidated memory for the extracted content
+  const insert: ConsolidatedMemoryInsert = {
+    repo_id: extracted.repo_id,
+    contributor_id: extracted.contributor_id,
+    content: extracted.content,
+    content_embedding: extracted.content_embedding,
+    memory_type: extracted.memory_type,
+    topics: extracted.topics,
+    importance_score: extracted.importance_score,
+    source_memories: [extracted.id],
+  };
+
+  const newConsolidated = await insertConsolidatedMemory(client, insert);
+
+  // Add the new consolidated memory ID to the existing memory's related_memories
+  const relatedMemories = [...(existing.related_memories ?? []), newConsolidated.id];
+  await updateConsolidatedMemory(client, existing.id, {
+    related_memories: relatedMemories,
+  });
+
+  await markMemoryConsolidated(client, extracted.id, newConsolidated.id);
+  return newConsolidated.id;
+}
+
+/**
+ * Create a new consolidated memory from an extracted memory.
+ */
+async function createNewConsolidated(
+  client: SupabaseClient,
+  extracted: ExtractedMemory,
+): Promise<string> {
+  const insert: ConsolidatedMemoryInsert = {
+    repo_id: extracted.repo_id,
+    contributor_id: extracted.contributor_id,
+    content: extracted.content,
+    content_embedding: extracted.content_embedding,
+    memory_type: extracted.memory_type,
+    topics: extracted.topics,
+    importance_score: extracted.importance_score,
+    source_memories: [extracted.id],
+  };
+
+  const consolidated = await insertConsolidatedMemory(client, insert);
+  await markMemoryConsolidated(client, extracted.id, consolidated.id);
+  return consolidated.id;
+}
+
+/**
+ * Run the consolidator agent: fetch unconsolidated memories, deduplicate, merge, or create.
+ * This is the core function called by the Inngest cron job.
+ */
+export async function runConsolidator(
+  client: SupabaseClient,
+  repoId: string,
+): Promise<ConsolidationRunResult> {
+  const result: ConsolidationRunResult = {
+    memoriesProcessed: 0,
+    memoriesMerged: 0,
+    memoriesLinked: 0,
+    memoriesCreated: 0,
+    errors: 0,
+  };
+
+  const unconsolidated = await getUnconsolidatedMemories(client, BATCH_SIZE);
+  if (unconsolidated.length === 0) {
+    return result;
+  }
+
+  // Load all consolidated memories with embeddings for similarity comparison
+  const consolidated = await getConsolidatedMemoriesWithEmbeddings(client, repoId);
+
+  for (const memory of unconsolidated) {
+    try {
+      // If memory has no embedding, create new consolidated entry (can't compare similarity)
+      if (!memory.content_embedding) {
+        await createNewConsolidated(client, memory);
+        result.memoriesProcessed++;
+        result.memoriesCreated++;
+        continue;
+      }
+
+      const bestMatch = findBestMatch(memory.content_embedding, consolidated);
+
+      if (bestMatch && bestMatch.similarity >= DUPLICATE_THRESHOLD) {
+        // Duplicate — merge via LLM
+        await mergeMemory(client, memory, bestMatch.match);
+        result.memoriesProcessed++;
+        result.memoriesMerged++;
+      } else if (bestMatch && bestMatch.similarity >= RELATED_THRESHOLD) {
+        // Related — link
+        const newId = await linkMemory(client, memory, bestMatch.match);
+        result.memoriesProcessed++;
+        result.memoriesLinked++;
+
+        // Add the newly created consolidated memory to the pool for subsequent comparisons
+        consolidated.push({
+          id: newId,
+          repo_id: memory.repo_id,
+          contributor_id: memory.contributor_id,
+          content: memory.content,
+          content_embedding: memory.content_embedding,
+          memory_type: memory.memory_type,
+          topics: memory.topics,
+          importance_score: memory.importance_score,
+          stability: 0.5,
+          related_memories: null,
+          source_memories: [memory.id],
+          tier: 'short',
+          access_count: 0,
+          last_accessed_at: null,
+          version: 1,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        });
+      } else {
+        // Novel — create new
+        const newId = await createNewConsolidated(client, memory);
+        result.memoriesProcessed++;
+        result.memoriesCreated++;
+
+        // Add to pool for subsequent comparisons
+        consolidated.push({
+          id: newId,
+          repo_id: memory.repo_id,
+          contributor_id: memory.contributor_id,
+          content: memory.content,
+          content_embedding: memory.content_embedding,
+          memory_type: memory.memory_type,
+          topics: memory.topics,
+          importance_score: memory.importance_score,
+          stability: 0.5,
+          related_memories: null,
+          source_memories: [memory.id],
+          tier: 'short',
+          access_count: 0,
+          last_accessed_at: null,
+          version: 1,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        });
+      }
+    } catch (error) {
+      result.errors++;
+      console.error(
+        `Consolidator failed for memory ${memory.id}:`,
+        error instanceof Error ? error.message : error,
+      );
+      // Memory stays unconsolidated — will be retried on next run
+    }
+  }
+
+  // Update agent state
+  await upsertAgentState(client, {
+    agent_name: 'consolidator',
+    repo_id: repoId,
+    last_run_at: new Date().toISOString(),
+    ...(result.errors === 0 ? { last_successful_at: new Date().toISOString() } : {}),
+    items_processed: result.memoriesProcessed,
+    error_count_24h: result.errors,
+    ...(result.errors > 0
+      ? { last_error: `${result.errors} memories failed in last run` }
+      : { last_error: null }),
+    metadata: {
+      last_run_memories_processed: result.memoriesProcessed,
+      last_run_merged: result.memoriesMerged,
+      last_run_linked: result.memoriesLinked,
+      last_run_created: result.memoriesCreated,
+      last_run_errors: result.errors,
+    },
+  });
+
+  return result;
+}

--- a/guardian/src/app.ts
+++ b/guardian/src/app.ts
@@ -4,6 +4,7 @@ import { verifySignature, processWebhookEvent } from './github/webhooks.js';
 import { getSupabaseClient } from './db/client.js';
 import { inngest } from './inngest/client.js';
 import { extractorCron } from './inngest/functions/extractor.js';
+import { consolidatorCron } from './inngest/functions/consolidator.js';
 
 export const app = new Hono();
 
@@ -11,7 +12,7 @@ export const app = new Hono();
 app.on(
   ['GET', 'POST', 'PUT'],
   '/api/inngest',
-  serveInngest({ client: inngest, functions: [extractorCron] }),
+  serveInngest({ client: inngest, functions: [extractorCron, consolidatorCron] }),
 );
 
 // Health check

--- a/guardian/src/db/queries.ts
+++ b/guardian/src/db/queries.ts
@@ -113,6 +113,20 @@ export async function updateConsolidatedMemory(
   return data as ConsolidatedMemory;
 }
 
+export async function getConsolidatedMemoriesWithEmbeddings(
+  client: SupabaseClient,
+  repoId: string,
+): Promise<ConsolidatedMemory[]> {
+  const { data, error } = await client
+    .from('consolidated_memories')
+    .select()
+    .eq('repo_id', repoId)
+    .not('content_embedding', 'is', null)
+    .order('updated_at', { ascending: false });
+  if (error) throw error;
+  return (data ?? []) as ConsolidatedMemory[];
+}
+
 // -- Contributor Profiles --
 
 export async function upsertContributorProfile(

--- a/guardian/src/inngest/functions/consolidator.ts
+++ b/guardian/src/inngest/functions/consolidator.ts
@@ -1,0 +1,26 @@
+import { inngest } from '../client.js';
+import { getSupabaseClient } from '../../db/client.js';
+import { loadConfig } from '../../config.js';
+import { runConsolidator } from '../../agents/consolidator.js';
+
+/**
+ * Inngest cron function: runs every hour to consolidate extracted memories.
+ */
+export const consolidatorCron = inngest.createFunction(
+  {
+    id: 'consolidator-cron',
+    name: 'Consolidator Agent — Deduplicate & Merge Memories',
+  },
+  { cron: '0 * * * *' },
+  async () => {
+    const config = loadConfig();
+    const client = getSupabaseClient();
+    const result = await runConsolidator(client, config.GUARDIAN_REPO);
+
+    console.log(
+      `Consolidator run complete: ${result.memoriesProcessed} processed, ${result.memoriesMerged} merged, ${result.memoriesLinked} linked, ${result.memoriesCreated} created, ${result.errors} errors`,
+    );
+
+    return result;
+  },
+);

--- a/guardian/src/llm/prompts.ts
+++ b/guardian/src/llm/prompts.ts
@@ -126,3 +126,53 @@ Author: ${username}
 Content:
 ${contentText}`;
 }
+
+// -- Consolidation / Merge Prompts --
+
+/** Schema for the merged memory output from the LLM. */
+export interface MergedMemoryLLM {
+  merged_content: string;
+  topics: string[];
+}
+
+export const MERGE_SYSTEM_PROMPT = `You are a memory consolidation agent for the ai-continuity-framework project.
+Your job is to merge two semantically similar memories into a single, more comprehensive memory.
+
+Guidelines:
+- Combine the information from both memories into one clear, self-contained statement
+- Preserve all important details from both — do not drop facts
+- Resolve contradictions by keeping the more specific or recent information
+- Keep the merged content concise but complete
+- Return a unified set of topics that covers both memories
+- Topics should be lowercase, hyphenated (e.g., "memory-decay", "agent-architecture")`;
+
+export const MERGE_TOOL_SCHEMA: Anthropic.Tool = {
+  name: 'merge_memories',
+  description: 'Merge two similar memories into a single consolidated memory',
+  input_schema: {
+    type: 'object',
+    properties: {
+      merged_content: {
+        type: 'string',
+        description: 'The merged memory content — a clear, self-contained statement',
+      },
+      topics: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Unified lowercase hyphenated topic tags for the merged memory',
+      },
+    },
+    required: ['merged_content', 'topics'],
+  },
+};
+
+/** Build the user message for merging two memories. */
+export function buildMergeUserMessage(existingContent: string, newContent: string): string {
+  return `Existing memory:
+${existingContent}
+
+New memory:
+${newContent}
+
+Merge these two memories into a single, comprehensive memory.`;
+}


### PR DESCRIPTION
## Summary

- **Consolidator Agent** (`guardian/src/agents/consolidator.ts`) — Fetches unconsolidated extracted memories, computes cosine similarity against existing consolidated memories, and routes each through one of three paths: merge (>0.92 similarity via LLM), link (0.75-0.92 as related memories), or create new (<0.75)
- **Merge prompts** (`guardian/src/llm/prompts.ts`) — `MERGE_SYSTEM_PROMPT`, `MERGE_TOOL_SCHEMA`, and `buildMergeUserMessage()` for Claude Sonnet merge operations
- **Inngest cron** (`guardian/src/inngest/functions/consolidator.ts`) — Hourly cron job (`0 * * * *`) that runs the consolidator, registered in `app.ts`
- **DB query** (`guardian/src/db/queries.ts`) — Added `getConsolidatedMemoriesWithEmbeddings()` to fetch all consolidated memories that have embeddings for similarity comparison
- **16 tests** (`guardian/src/__tests__/consolidator.test.ts`) — Covers merge, link, create, importance boosting, LLM failure handling, no-embedding edge case, early return, and agent state updates

## Technical details

- LLM model: `claude-sonnet-4-6-20250514` for merge synthesis
- Cosine similarity computed in application code (batch is small enough)
- Merged importance = `min(max(existing, new) * 1.1, 1.0)`
- LLM failures leave memory unconsolidated for retry on next run
- DB failures throw (Inngest retries the whole function)
- `cosineSimilarity()` exported as a utility for reuse

## Test plan

- [x] Sacred Four passes: typecheck, lint, test (69 tests), build
- [x] 16 new consolidator tests covering all paths
- [x] Existing 53 tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)