### PR TITLE
feat(guardian): Supabase Auth middleware and user management

### DIFF
--- a/guardian/.env.example
+++ b/guardian/.env.example
@@ -8,6 +8,7 @@ GITHUB_INSTALLATION_TOKEN=
 # Supabase
 SUPABASE_URL=https://effzofflphvbyvcenvly.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=
+SUPABASE_ANON_KEY=
 
 # Anthropic
 ANTHROPIC_API_KEY=

--- a/guardian/src/__tests__/auth.test.ts
+++ b/guardian/src/__tests__/auth.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import {
+  authMiddleware,
+  getAuthUser,
+  setAnonClient,
+  resetAnonClient,
+  type AuthUser,
+} from '../auth/supabase-auth.js';
+import { ensureUserProfile, linkGitHubIdentity, unlinkGitHubIdentity } from '../auth/identity.js';
+
+// -- Auth Middleware Tests --
+
+// Mock Supabase auth.getUser
+const mockGetUser = vi.fn();
+
+function createMockSupabaseClient() {
+  return {
+    auth: {
+      getUser: mockGetUser,
+    },
+  };
+}
+
+describe('authMiddleware', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAnonClient();
+
+    // Set up mock anon client
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setAnonClient(createMockSupabaseClient() as any);
+
+    // Create a fresh Hono app with auth middleware protecting a test route
+    app = new Hono();
+    app.use('/protected/*', authMiddleware());
+    app.get('/protected/test', (c) => {
+      const user = getAuthUser(c);
+      return c.json({ user });
+    });
+  });
+
+  it('rejects requests without Authorization header', async () => {
+    const res = await app.request('/protected/test');
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe('Missing Authorization header');
+  });
+
+  it('rejects requests with invalid Authorization format', async () => {
+    const res = await app.request('/protected/test', {
+      headers: { Authorization: 'InvalidFormat' },
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe('Invalid Authorization header format');
+  });
+
+  it('rejects invalid JWT token', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Invalid token' },
+    });
+
+    const res = await app.request('/protected/test', {
+      headers: { Authorization: 'Bearer invalid-token' },
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe('Invalid or expired token');
+  });
+
+  it('sets user context for valid JWT', async () => {
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: {
+          id: 'auth-uid-123',
+          email: 'test@example.com',
+        },
+      },
+      error: null,
+    });
+
+    const res = await app.request('/protected/test', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: AuthUser };
+    expect(body.user.id).toBe('auth-uid-123');
+    expect(body.user.email).toBe('test@example.com');
+  });
+
+  it('handles auth service errors gracefully', async () => {
+    mockGetUser.mockRejectedValue(new Error('Service unavailable'));
+
+    const res = await app.request('/protected/test', {
+      headers: { Authorization: 'Bearer some-token' },
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe('Authentication failed');
+  });
+});
+
+// -- Identity Tests --
+
+// Hoist mock state so it's available when vi.mock factories run
+const mockState = vi.hoisted(() => ({
+  existingProfile: null as Record<string, unknown> | null,
+  insertedProfile: null as Record<string, unknown> | null,
+  updatedProfile: null as Record<string, unknown> | null,
+}));
+
+vi.mock('../db/queries.js', () => ({
+  getUserProfileByAuthId: vi.fn(() => {
+    if (mockState.existingProfile) {
+      return Promise.resolve(mockState.existingProfile);
+    }
+    // Return null to simulate no existing profile
+    return Promise.resolve(null);
+  }),
+  insertUserProfile: vi.fn((_client: unknown, data: Record<string, unknown>) => {
+    mockState.insertedProfile = data;
+    return Promise.resolve({
+      id: 'user-uuid-001',
+      supabase_auth_id: data.supabase_auth_id,
+      email: data.email,
+      display_name: data.display_name,
+      github_contributor_id: null,
+      first_seen_at: new Date().toISOString(),
+      last_seen_at: new Date().toISOString(),
+      interaction_count: 0,
+      summary: null,
+      interests: null,
+      communication_style: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+  }),
+}));
+
+// Mock Supabase client for identity functions (direct DB calls)
+function createMockDbClient(returnData: Record<string, unknown> | null = null) {
+  return {
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: returnData,
+                error: null,
+              }),
+            ),
+          })),
+        })),
+      })),
+    })),
+  };
+}
+
+describe('ensureUserProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.existingProfile = null;
+    mockState.insertedProfile = null;
+  });
+
+  it('creates new profile on first call', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = {} as any;
+    const result = await ensureUserProfile(client, 'auth-123', 'test@example.com', 'Test User');
+
+    expect(mockState.insertedProfile).not.toBeNull();
+    expect(mockState.insertedProfile!.supabase_auth_id).toBe('auth-123');
+    expect(mockState.insertedProfile!.email).toBe('test@example.com');
+    expect(mockState.insertedProfile!.display_name).toBe('Test User');
+    expect(result.id).toBe('user-uuid-001');
+  });
+
+  it('returns existing profile on subsequent calls', async () => {
+    mockState.existingProfile = {
+      id: 'existing-uuid',
+      supabase_auth_id: 'auth-123',
+      email: 'existing@example.com',
+      display_name: 'Existing User',
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = {} as any;
+    const result = await ensureUserProfile(client, 'auth-123', 'existing@example.com');
+
+    expect(result.id).toBe('existing-uuid');
+    expect(mockState.insertedProfile).toBeNull();
+  });
+
+  it('handles missing email and display name', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = {} as any;
+    const result = await ensureUserProfile(client, 'auth-456', undefined);
+
+    expect(mockState.insertedProfile).not.toBeNull();
+    expect(mockState.insertedProfile!.email).toBeNull();
+    expect(mockState.insertedProfile!.display_name).toBeNull();
+    expect(result.id).toBe('user-uuid-001');
+  });
+});
+
+describe('linkGitHubIdentity', () => {
+  it('links user to contributor profile', async () => {
+    const linkedProfile = {
+      id: 'user-uuid-001',
+      github_contributor_id: 'contrib-uuid-001',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = createMockDbClient(linkedProfile) as any;
+
+    const result = await linkGitHubIdentity(client, 'user-uuid-001', 'contrib-uuid-001');
+    expect(result.github_contributor_id).toBe('contrib-uuid-001');
+    expect(client.from).toHaveBeenCalledWith('user_profiles');
+  });
+});
+
+describe('unlinkGitHubIdentity', () => {
+  it('removes the link from user profile', async () => {
+    const unlinkedProfile = {
+      id: 'user-uuid-001',
+      github_contributor_id: null,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = createMockDbClient(unlinkedProfile) as any;
+
+    const result = await unlinkGitHubIdentity(client, 'user-uuid-001');
+    expect(result.github_contributor_id).toBeNull();
+    expect(client.from).toHaveBeenCalledWith('user_profiles');
+  });
+});

--- a/guardian/src/auth/identity.ts
+++ b/guardian/src/auth/identity.ts
@@ -1,0 +1,70 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { UserProfile } from '../db/schema.js';
+import { getUserProfileByAuthId, insertUserProfile } from '../db/queries.js';
+
+/**
+ * Ensure a user profile exists for the given Supabase Auth user.
+ * Creates one on first login, returns existing on subsequent calls.
+ */
+export async function ensureUserProfile(
+  client: SupabaseClient,
+  authId: string,
+  email: string | undefined,
+  displayName?: string,
+): Promise<UserProfile> {
+  // Check for existing profile
+  const existing = await getUserProfileByAuthId(client, authId);
+  if (existing) {
+    return existing;
+  }
+
+  // Create new profile
+  return insertUserProfile(client, {
+    supabase_auth_id: authId,
+    email: email ?? null,
+    display_name: displayName ?? null,
+  });
+}
+
+/**
+ * Link a user profile to a GitHub contributor profile.
+ * Sets the github_contributor_id on the user_profiles record.
+ */
+export async function linkGitHubIdentity(
+  client: SupabaseClient,
+  userId: string,
+  githubContributorId: string,
+): Promise<UserProfile> {
+  const { data, error } = await client
+    .from('user_profiles')
+    .update({
+      github_contributor_id: githubContributorId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', userId)
+    .select()
+    .single();
+  if (error) throw error;
+  return data as UserProfile;
+}
+
+/**
+ * Unlink a user profile from its GitHub contributor profile.
+ * Removes the github_contributor_id from the user_profiles record.
+ */
+export async function unlinkGitHubIdentity(
+  client: SupabaseClient,
+  userId: string,
+): Promise<UserProfile> {
+  const { data, error } = await client
+    .from('user_profiles')
+    .update({
+      github_contributor_id: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', userId)
+    .select()
+    .single();
+  if (error) throw error;
+  return data as UserProfile;
+}

--- a/guardian/src/auth/supabase-auth.ts
+++ b/guardian/src/auth/supabase-auth.ts
@@ -1,0 +1,99 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { Context, MiddlewareHandler } from 'hono';
+import { loadConfig } from '../config.js';
+
+/**
+ * Authenticated user extracted from Supabase JWT.
+ */
+export interface AuthUser {
+  id: string; // Supabase Auth UID
+  email: string | undefined;
+}
+
+// Hono context variable key for the authenticated user
+const AUTH_USER_KEY = 'authUser';
+
+let anonClient: SupabaseClient | null = null;
+
+/**
+ * Get a Supabase client initialized with the anon key.
+ * Used for JWT verification via auth.getUser().
+ */
+function getAnonClient(): SupabaseClient {
+  if (!anonClient) {
+    const config = loadConfig();
+    if (!config.SUPABASE_ANON_KEY) {
+      throw new Error('SUPABASE_ANON_KEY is required for auth middleware');
+    }
+    anonClient = createClient(config.SUPABASE_URL, config.SUPABASE_ANON_KEY);
+  }
+  return anonClient;
+}
+
+/**
+ * Reset the anon client singleton (for testing).
+ */
+export function resetAnonClient(): void {
+  anonClient = null;
+}
+
+/**
+ * Set a pre-built anon client (for testing).
+ */
+export function setAnonClient(client: SupabaseClient): void {
+  anonClient = client;
+}
+
+/**
+ * Hono middleware that validates Supabase JWT from Authorization header.
+ *
+ * On success, sets the authenticated user on the Hono context.
+ * On failure, returns 401.
+ */
+export function authMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const authHeader = c.req.header('Authorization');
+    if (!authHeader) {
+      return c.json({ error: 'Missing Authorization header' }, 401);
+    }
+
+    const token = authHeader.replace(/^Bearer\s+/i, '');
+    if (!token || token === authHeader) {
+      return c.json({ error: 'Invalid Authorization header format' }, 401);
+    }
+
+    try {
+      const client = getAnonClient();
+      const {
+        data: { user },
+        error,
+      } = await client.auth.getUser(token);
+
+      if (error || !user) {
+        return c.json({ error: 'Invalid or expired token' }, 401);
+      }
+
+      const authUser: AuthUser = {
+        id: user.id,
+        email: user.email,
+      };
+
+      c.set(AUTH_USER_KEY, authUser);
+      await next();
+    } catch {
+      return c.json({ error: 'Authentication failed' }, 401);
+    }
+  };
+}
+
+/**
+ * Get the authenticated user from the Hono context.
+ * Must be used after authMiddleware().
+ */
+export function getAuthUser(c: Context): AuthUser {
+  const user = c.get(AUTH_USER_KEY) as AuthUser | undefined;
+  if (!user) {
+    throw new Error('No authenticated user in context. Is authMiddleware() applied?');
+  }
+  return user;
+}

--- a/guardian/src/config.ts
+++ b/guardian/src/config.ts
@@ -8,6 +8,7 @@ const envSchema = z.object({
   // Supabase
   SUPABASE_URL: z.string().url(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  SUPABASE_ANON_KEY: z.string().min(1).optional(),
 
   // GitHub App
   GITHUB_APP_ID: z.string().min(1),


### PR DESCRIPTION
## Summary
- **Auth middleware** (`authMiddleware()`) validates Supabase JWT from Authorization header, rejects 401 for missing/invalid tokens, sets authenticated user on Hono context
- **Identity helpers** (`ensureUserProfile`, `linkGitHubIdentity`, `unlinkGitHubIdentity`) manage user profile creation on first login and GitHub contributor linking
- **Config update** — `SUPABASE_ANON_KEY` added as optional env var (not required for Phase 1 webhook processing)
- **10 new tests** covering auth rejection, JWT validation, user profile creation, and identity linking

## Files changed
- `guardian/src/auth/supabase-auth.ts` — Auth middleware + getAuthUser helper
- `guardian/src/auth/identity.ts` — User profile management functions
- `guardian/src/config.ts` — SUPABASE_ANON_KEY in env schema (optional)
- `guardian/.env.example` — SUPABASE_ANON_KEY placeholder
- `guardian/src/__tests__/auth.test.ts` — 10 tests

## Test plan
- [x] Sacred Four passing (typecheck, lint, 173 tests, build)
- [x] authMiddleware rejects missing Authorization header (401)
- [x] authMiddleware rejects invalid format (401)
- [x] authMiddleware rejects invalid JWT (401)
- [x] authMiddleware sets user context for valid JWT
- [x] authMiddleware handles service errors gracefully
- [x] ensureUserProfile creates new profile on first call
- [x] ensureUserProfile returns existing on subsequent calls
- [x] ensureUserProfile handles missing email/displayName
- [x] linkGitHubIdentity links user to contributor
- [x] unlinkGitHubIdentity removes the link

🤖 Generated with [Claude Code](https://claude.com/claude-code)