### PR TITLE
feat(guardian): Chat API with memory-augmented responses

### DIFF
--- a/guardian/src/__tests__/chat-api.test.ts
+++ b/guardian/src/__tests__/chat-api.test.ts
@@ -1,0 +1,691 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+// -- Hoisted mock state --
+
+const mockState = vi.hoisted(() => ({
+  // Auth
+  authUser: { id: 'auth-uid-123', email: 'test@example.com' } as {
+    id: string;
+    email: string | undefined;
+  } | null,
+  // User profile
+  userProfile: {
+    id: 'user-uuid-001',
+    supabase_auth_id: 'auth-uid-123',
+    email: 'test@example.com',
+    display_name: 'Test User',
+    github_contributor_id: null,
+    first_seen_at: '2026-01-01T00:00:00Z',
+    last_seen_at: '2026-03-16T00:00:00Z',
+    interaction_count: 5,
+    summary: null,
+    interests: null,
+    communication_style: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-03-16T00:00:00Z',
+  },
+  // Conversations
+  conversations: [] as Array<{
+    id: string;
+    user_id: string;
+    title: string | null;
+    status: string;
+    message_count: number;
+    created_at: string;
+    updated_at: string;
+  }>,
+  // Messages
+  messages: [] as Array<{
+    id: string;
+    conversation_id: string;
+    user_id: string;
+    role: string;
+    content: string;
+    processed: boolean;
+    processed_at: string | null;
+    created_at: string;
+  }>,
+  // LLM response
+  llmResponseText: 'I remember that. Here is my response based on your memories.',
+  // Retrieval result
+  memoriesUsed: 2,
+  // Counters for tracking calls
+  insertedMessages: [] as Array<{
+    conversation_id: string;
+    user_id: string;
+    role: string;
+    content: string;
+  }>,
+  insertedConversations: [] as Array<{ user_id: string; title: string | null }>,
+  // Error simulation
+  llmShouldFail: false,
+}));
+
+// -- Mock auth middleware --
+
+vi.mock('../auth/supabase-auth.js', () => ({
+  authMiddleware: vi.fn(() => {
+    return async (
+      c: {
+        set: (key: string, val: unknown) => void;
+        json: (body: unknown, status: number) => unknown;
+        req: { header: (name: string) => string | undefined };
+      },
+      next: () => Promise<void>,
+    ) => {
+      if (!mockState.authUser) {
+        return c.json({ error: 'Missing Authorization header' }, 401);
+      }
+      // Check for Authorization header
+      const authHeader = c.req.header('Authorization');
+      if (!authHeader) {
+        return c.json({ error: 'Missing Authorization header' }, 401);
+      }
+      c.set('authUser', mockState.authUser);
+      await next();
+    };
+  }),
+  getAuthUser: vi.fn((c: { get: (key: string) => unknown }) => {
+    return c.get('authUser');
+  }),
+  resetAnonClient: vi.fn(),
+  setAnonClient: vi.fn(),
+}));
+
+// -- Mock identity --
+
+vi.mock('../auth/identity.js', () => ({
+  ensureUserProfile: vi.fn(async () => mockState.userProfile),
+}));
+
+// -- Mock DB client --
+
+vi.mock('../db/client.js', () => ({
+  getSupabaseClient: vi.fn(() => ({})),
+}));
+
+// -- Mock DB queries --
+
+let messageIdCounter = 0;
+let conversationIdCounter = 0;
+
+vi.mock('../db/queries.js', () => ({
+  insertConversation: vi.fn(
+    async (_client: unknown, data: { user_id: string; title?: string | null }) => {
+      conversationIdCounter++;
+      const conv = {
+        id: `conv-uuid-${conversationIdCounter}`,
+        user_id: data.user_id,
+        title: data.title ?? null,
+        status: 'active',
+        message_count: 0,
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T00:00:00Z',
+      };
+      mockState.insertedConversations.push({ user_id: data.user_id, title: data.title ?? null });
+      mockState.conversations.push(conv);
+      return conv;
+    },
+  ),
+  getConversationsByUser: vi.fn(async (_client: unknown, userId: string) => {
+    return mockState.conversations.filter((c) => c.user_id === userId);
+  }),
+  getConversationById: vi.fn(async (_client: unknown, id: string) => {
+    return mockState.conversations.find((c) => c.id === id) ?? null;
+  }),
+  insertMessage: vi.fn(
+    async (
+      _client: unknown,
+      data: { conversation_id: string; user_id: string; role: string; content: string },
+    ) => {
+      messageIdCounter++;
+      const msg = {
+        id: `msg-uuid-${messageIdCounter}`,
+        conversation_id: data.conversation_id,
+        user_id: data.user_id,
+        role: data.role,
+        content: data.content,
+        processed: false,
+        processed_at: null,
+        created_at: '2026-03-16T00:00:00Z',
+      };
+      mockState.insertedMessages.push(data);
+      mockState.messages.push(msg);
+      return msg;
+    },
+  ),
+  getMessagesByConversation: vi.fn(async (_client: unknown, convId: string) => {
+    return mockState.messages.filter((m) => m.conversation_id === convId);
+  }),
+  updateConversationMessageCount: vi.fn(async () => {}),
+  matchMemories: vi.fn(async () => []),
+  recordMemoryAccess: vi.fn(async () => {}),
+  getContributorById: vi.fn(async () => null),
+  getUserProfileByAuthId: vi.fn(async () => mockState.userProfile),
+  insertUserProfile: vi.fn(async () => mockState.userProfile),
+}));
+
+// -- Mock retriever --
+
+vi.mock('../agents/retriever.js', () => ({
+  runRetriever: vi.fn(async () => ({
+    memories: [
+      {
+        id: 'mem-001',
+        content: 'The team decided to use TypeScript strict mode.',
+        memory_type: 'decision',
+        topics: ['typescript'],
+        importance_score: 0.8,
+        semantic_score: 0.85,
+        recency_score: 1.0,
+        final_score: 0.67,
+      },
+      {
+        id: 'mem-002',
+        content: 'Hub-and-spoke architecture is the preferred pattern.',
+        memory_type: 'decision',
+        topics: ['architecture'],
+        importance_score: 0.9,
+        semantic_score: 0.8,
+        recency_score: 0.9,
+        final_score: 0.72,
+      },
+    ],
+    contributorProfile: null,
+    contextBlock: '## Relevant Memories\n- (decision [typescript]) TypeScript strict mode.',
+    latencyMs: 30,
+    degradation: 'full' as const,
+  })),
+}));
+
+// -- Mock LLM client --
+
+vi.mock('../llm/client.js', () => ({
+  getAnthropicClient: vi.fn(() => ({
+    messages: {
+      create: vi.fn(async () => {
+        if (mockState.llmShouldFail) {
+          throw new Error('LLM API error');
+        }
+        return {
+          content: [{ type: 'text', text: mockState.llmResponseText }],
+        };
+      }),
+    },
+  })),
+  getOpenAIClient: vi.fn(),
+  resetLLMClients: vi.fn(),
+}));
+
+// -- Mock embeddings --
+
+vi.mock('../llm/embeddings.js', () => ({
+  generateEmbedding: vi.fn(async () => null),
+}));
+
+// -- Mock config --
+
+vi.mock('../config.js', () => ({
+  loadConfig: vi.fn(() => ({
+    PORT: 3000,
+    LOG_LEVEL: 'info',
+    NODE_ENV: 'test',
+    SUPABASE_URL: 'https://test.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'test-service-key',
+    SUPABASE_ANON_KEY: 'test-anon-key',
+    ANTHROPIC_API_KEY: 'test-anthropic-key',
+    OPENAI_API_KEY: 'test-openai-key',
+    GITHUB_APP_ID: 'test-app-id',
+    GITHUB_PRIVATE_KEY: 'test-private-key',
+    GITHUB_WEBHOOK_SECRET: 'test-webhook-secret',
+    GUARDIAN_REPO: 'leonardrknight/ai-continuity-framework',
+  })),
+}));
+
+// Import after mocks
+import { chatRouter, conversationsRouter } from '../chat/router.js';
+
+// -- Test app setup --
+
+function createTestApp() {
+  const app = new Hono();
+  app.route('/api/chat', chatRouter);
+  app.route('/api/conversations', conversationsRouter);
+  return app;
+}
+
+// -- Tests --
+
+describe('POST /api/chat', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.authUser = { id: 'auth-uid-123', email: 'test@example.com' };
+    mockState.conversations = [];
+    mockState.messages = [];
+    mockState.insertedMessages = [];
+    mockState.insertedConversations = [];
+    mockState.llmResponseText = 'I remember that. Here is my response based on your memories.';
+    mockState.llmShouldFail = false;
+    messageIdCounter = 0;
+    conversationIdCounter = 0;
+    app = createTestApp();
+  });
+
+  it('sends message and gets response with memory context', async () => {
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({ message: 'What architecture do we use?' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.response).toBe(mockState.llmResponseText);
+    expect(body.conversation_id).toBeDefined();
+    expect(body.user_message_id).toBeDefined();
+    expect(body.assistant_message_id).toBeDefined();
+    expect(body.memories_used).toBe(2);
+  });
+
+  it('creates new conversation when no conversation_id provided', async () => {
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({ message: 'Hello Guardian' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.conversation_id).toBeDefined();
+    expect(mockState.insertedConversations.length).toBe(1);
+    expect(mockState.insertedConversations[0].title).toBe('Hello Guardian');
+  });
+
+  it('appends to existing conversation', async () => {
+    // Create a conversation first
+    const existingConv = {
+      id: 'conv-existing',
+      user_id: 'user-uuid-001',
+      title: 'Existing conversation',
+      status: 'active',
+      message_count: 2,
+      created_at: '2026-03-16T00:00:00Z',
+      updated_at: '2026-03-16T00:00:00Z',
+    };
+    mockState.conversations.push(existingConv);
+
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({
+        conversation_id: 'conv-existing',
+        message: 'Follow up question',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.conversation_id).toBe('conv-existing');
+    // No new conversation should be created
+    expect(mockState.insertedConversations.length).toBe(0);
+  });
+
+  it('rejects unauthenticated requests (401)', async () => {
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // No Authorization header
+      },
+      body: JSON.stringify({ message: 'Hello' }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it('stores both user and assistant messages', async () => {
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({ message: 'Tell me about memory systems' }),
+    });
+
+    expect(res.status).toBe(200);
+    // Should have inserted 2 messages: user + assistant
+    expect(mockState.insertedMessages.length).toBe(2);
+    expect(mockState.insertedMessages[0].role).toBe('user');
+    expect(mockState.insertedMessages[0].content).toBe('Tell me about memory systems');
+    expect(mockState.insertedMessages[1].role).toBe('assistant');
+    expect(mockState.insertedMessages[1].content).toBe(mockState.llmResponseText);
+  });
+
+  it('rejects empty message', async () => {
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({ message: '' }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe('Message is required');
+  });
+
+  it('returns 404 for non-existent conversation', async () => {
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({
+        conversation_id: 'non-existent',
+        message: 'Hello',
+      }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 for another user's conversation", async () => {
+    // Create a conversation owned by a different user
+    mockState.conversations.push({
+      id: 'conv-other',
+      user_id: 'other-user-uuid',
+      title: 'Other user chat',
+      status: 'active',
+      message_count: 0,
+      created_at: '2026-03-16T00:00:00Z',
+      updated_at: '2026-03-16T00:00:00Z',
+    });
+
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({
+        conversation_id: 'conv-other',
+        message: 'Sneaky message',
+      }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /api/conversations', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.authUser = { id: 'auth-uid-123', email: 'test@example.com' };
+    mockState.conversations = [];
+    mockState.messages = [];
+    mockState.insertedMessages = [];
+    mockState.insertedConversations = [];
+    messageIdCounter = 0;
+    conversationIdCounter = 0;
+    app = createTestApp();
+  });
+
+  it("returns user's conversations", async () => {
+    // Add some conversations for this user
+    mockState.conversations = [
+      {
+        id: 'conv-1',
+        user_id: 'user-uuid-001',
+        title: 'First chat',
+        status: 'active',
+        message_count: 5,
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T10:00:00Z',
+      },
+      {
+        id: 'conv-2',
+        user_id: 'user-uuid-001',
+        title: 'Second chat',
+        status: 'active',
+        message_count: 3,
+        created_at: '2026-03-15T00:00:00Z',
+        updated_at: '2026-03-16T08:00:00Z',
+      },
+    ];
+
+    const res = await app.request('/api/conversations', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { conversations: Array<{ id: string }> };
+    expect(body.conversations).toHaveLength(2);
+    expect(body.conversations[0].id).toBe('conv-1');
+  });
+
+  it('rejects unauthenticated requests (401)', async () => {
+    const res = await app.request('/api/conversations');
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/conversations', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.authUser = { id: 'auth-uid-123', email: 'test@example.com' };
+    mockState.conversations = [];
+    mockState.insertedConversations = [];
+    conversationIdCounter = 0;
+    app = createTestApp();
+  });
+
+  it('creates a new conversation with title', async () => {
+    const res = await app.request('/api/conversations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({ title: 'Memory architecture discussion' }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { conversation: { id: string; title: string } };
+    expect(body.conversation.title).toBe('Memory architecture discussion');
+    expect(body.conversation.id).toBeDefined();
+  });
+
+  it('creates a new conversation without title', async () => {
+    const res = await app.request('/api/conversations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { conversation: { id: string; title: string | null } };
+    expect(body.conversation.title).toBeNull();
+  });
+});
+
+describe('GET /api/conversations/:id', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.authUser = { id: 'auth-uid-123', email: 'test@example.com' };
+    mockState.conversations = [];
+    mockState.messages = [];
+    messageIdCounter = 0;
+    app = createTestApp();
+  });
+
+  it('returns conversation with messages', async () => {
+    mockState.conversations = [
+      {
+        id: 'conv-abc',
+        user_id: 'user-uuid-001',
+        title: 'Test chat',
+        status: 'active',
+        message_count: 2,
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T00:00:00Z',
+      },
+    ];
+    mockState.messages = [
+      {
+        id: 'msg-1',
+        conversation_id: 'conv-abc',
+        user_id: 'user-uuid-001',
+        role: 'user',
+        content: 'Hello',
+        processed: false,
+        processed_at: null,
+        created_at: '2026-03-16T00:00:00Z',
+      },
+      {
+        id: 'msg-2',
+        conversation_id: 'conv-abc',
+        user_id: 'user-uuid-001',
+        role: 'assistant',
+        content: 'Hi there!',
+        processed: false,
+        processed_at: null,
+        created_at: '2026-03-16T00:01:00Z',
+      },
+    ];
+
+    const res = await app.request('/api/conversations/conv-abc', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      conversation: { id: string };
+      messages: Array<{ id: string; role: string; content: string }>;
+    };
+    expect(body.conversation.id).toBe('conv-abc');
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].role).toBe('user');
+    expect(body.messages[1].role).toBe('assistant');
+  });
+
+  it("rejects access to other user's conversations", async () => {
+    mockState.conversations = [
+      {
+        id: 'conv-other',
+        user_id: 'different-user-uuid',
+        title: 'Not your chat',
+        status: 'active',
+        message_count: 0,
+        created_at: '2026-03-16T00:00:00Z',
+        updated_at: '2026-03-16T00:00:00Z',
+      },
+    ];
+
+    const res = await app.request('/api/conversations/conv-other', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe('Access denied');
+  });
+
+  it('returns 404 for non-existent conversation', async () => {
+    const res = await app.request('/api/conversations/non-existent', {
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('Response generation includes retrieved memories', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.authUser = { id: 'auth-uid-123', email: 'test@example.com' };
+    mockState.conversations = [];
+    mockState.messages = [];
+    mockState.insertedMessages = [];
+    mockState.insertedConversations = [];
+    mockState.llmResponseText = 'Based on my memories, TypeScript strict mode is standard.';
+    mockState.llmShouldFail = false;
+    messageIdCounter = 0;
+    conversationIdCounter = 0;
+    app = createTestApp();
+  });
+
+  it('memories_used count is included in response', async () => {
+    const res = await app.request('/api/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer valid-token',
+      },
+      body: JSON.stringify({ message: 'What TypeScript config do we use?' }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.memories_used).toBe(2);
+    expect(body.response).toContain('TypeScript');
+  });
+});
+
+describe('Auto-title generation', () => {
+  it('generates title from first message', async () => {
+    // Import after mocks are set up
+    const { generateAutoTitle } = await import('../chat/response.js');
+
+    // '!' is a sentence delimiter, so 'Hello Guardian!' -> 'Hello Guardian'
+    expect(generateAutoTitle('Hello Guardian!')).toBe('Hello Guardian');
+    // '?' is a sentence delimiter, so the title is 'What is the architecture of this project'
+    expect(generateAutoTitle('What is the architecture of this project?')).toBe(
+      'What is the architecture of this project',
+    );
+  });
+
+  it('truncates long messages for title', async () => {
+    const { generateAutoTitle } = await import('../chat/response.js');
+
+    const longMessage =
+      'This is a very long message that should be truncated because it exceeds sixty characters in total length';
+    const title = generateAutoTitle(longMessage);
+    expect(title.length).toBeLessThanOrEqual(60);
+    expect(title).toContain('...');
+  });
+
+  it('uses first sentence as title', async () => {
+    const { generateAutoTitle } = await import('../chat/response.js');
+
+    expect(generateAutoTitle('First sentence. Second sentence.')).toBe('First sentence');
+    expect(generateAutoTitle('Question? More text.')).toBe('Question');
+  });
+});

--- a/guardian/src/app.ts
+++ b/guardian/src/app.ts
@@ -12,8 +12,13 @@ import { extractorCron } from './inngest/functions/extractor.js';
 import { consolidatorCron } from './inngest/functions/consolidator.js';
 import { curatorCron } from './inngest/functions/curator.js';
 import { responderHandler } from './inngest/functions/responder.js';
+import { chatRouter, conversationsRouter } from './chat/router.js';
 
 export const app = new Hono();
+
+// Chat API routes (authenticated)
+app.route('/api/chat', chatRouter);
+app.route('/api/conversations', conversationsRouter);
 
 // Inngest endpoint — serves all registered functions
 app.on(

--- a/guardian/src/chat/response.ts
+++ b/guardian/src/chat/response.ts
@@ -1,0 +1,115 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getAnthropicClient } from '../llm/client.js';
+import { CHAT_SYSTEM_PROMPT, buildChatContextBlock } from '../llm/prompts.js';
+import { runRetriever } from '../agents/retriever.js';
+import { getMessagesByConversation } from '../db/queries.js';
+import type { UserProfile, Message } from '../db/schema.js';
+
+/** Claude Sonnet model for chat responses. */
+const CHAT_MODEL = 'claude-sonnet-4-6-20250514';
+
+/** Maximum conversation history messages to include in context. */
+const MAX_HISTORY_MESSAGES = 20;
+
+/** Maximum tokens for chat response. */
+const MAX_TOKENS = 1024;
+
+/** Default repo ID for memory retrieval. */
+const DEFAULT_REPO_ID = 'leonardrknight/ai-continuity-framework';
+
+/**
+ * Build the full system prompt with memory context injected.
+ */
+export function buildChatSystemPrompt(
+  memories: { content: string; memory_type: string; topics: string[] | null }[],
+  userProfile?: UserProfile | null,
+): string {
+  const contextBlock = buildChatContextBlock(memories, userProfile);
+
+  if (!contextBlock) {
+    return CHAT_SYSTEM_PROMPT;
+  }
+
+  return `${CHAT_SYSTEM_PROMPT}\n\n--- Memory Context ---\n${contextBlock}`;
+}
+
+/**
+ * Convert conversation history to Anthropic message format.
+ */
+function formatConversationHistory(
+  messages: Message[],
+): { role: 'user' | 'assistant'; content: string }[] {
+  return messages
+    .filter((m) => m.role === 'user' || m.role === 'assistant')
+    .map((m) => ({
+      role: m.role as 'user' | 'assistant',
+      content: m.content,
+    }));
+}
+
+/**
+ * Generate a chat response augmented with retrieved memories.
+ *
+ * Steps:
+ * 1. Get recent conversation history
+ * 2. Call Retriever with user message as query
+ * 3. Build system prompt with memories + user profile
+ * 4. Call Claude Sonnet
+ * 5. Return the response text
+ */
+export async function generateChatResponse(
+  client: SupabaseClient,
+  userMessage: string,
+  conversationId: string,
+  userId: string,
+  repoId?: string,
+): Promise<{ text: string; memoriesUsed: number }> {
+  const effectiveRepoId = repoId ?? DEFAULT_REPO_ID;
+
+  // Step 1: Get recent conversation history (before the current message)
+  const history = await getMessagesByConversation(client, conversationId, MAX_HISTORY_MESSAGES);
+
+  // Step 2: Retrieve relevant memories
+  const retrieval = await runRetriever(client, userMessage, effectiveRepoId, undefined);
+
+  // Step 3: Build system prompt
+  const systemPrompt = buildChatSystemPrompt(retrieval.memories, null);
+
+  // Step 4: Build messages array (history + current message)
+  const conversationMessages = formatConversationHistory(history);
+  conversationMessages.push({ role: 'user', content: userMessage });
+
+  // Step 5: Call Claude
+  const anthropic = getAnthropicClient();
+  const response = await anthropic.messages.create({
+    model: CHAT_MODEL,
+    max_tokens: MAX_TOKENS,
+    system: systemPrompt,
+    messages: conversationMessages,
+  });
+
+  // Extract text from response
+  const textBlock = response.content.find((block) => block.type === 'text');
+  const text = textBlock && 'text' in textBlock ? textBlock.text : '';
+
+  return {
+    text,
+    memoriesUsed: retrieval.memories.length,
+  };
+}
+
+/**
+ * Generate an auto-title from the first message in a conversation.
+ * Uses a simple heuristic: take the first sentence or first 50 chars.
+ */
+export function generateAutoTitle(message: string): string {
+  // Take first sentence
+  const firstSentence = message.split(/[.!?\n]/)[0]?.trim() ?? message.trim();
+
+  // Cap at 60 characters
+  if (firstSentence.length <= 60) {
+    return firstSentence;
+  }
+
+  return firstSentence.slice(0, 57) + '...';
+}

--- a/guardian/src/chat/router.ts
+++ b/guardian/src/chat/router.ts
@@ -1,0 +1,155 @@
+import { Hono } from 'hono';
+import { authMiddleware, getAuthUser } from '../auth/supabase-auth.js';
+import { ensureUserProfile } from '../auth/identity.js';
+import { getSupabaseClient } from '../db/client.js';
+import {
+  insertConversation,
+  getConversationsByUser,
+  getConversationById,
+  insertMessage,
+  getMessagesByConversation,
+  updateConversationMessageCount,
+} from '../db/queries.js';
+import { generateChatResponse, generateAutoTitle } from './response.js';
+
+export const chatRouter = new Hono();
+export const conversationsRouter = new Hono();
+
+// Apply auth to all chat and conversation routes
+chatRouter.use('*', authMiddleware());
+conversationsRouter.use('*', authMiddleware());
+
+/**
+ * POST /api/chat — Send a message and get a memory-augmented response.
+ *
+ * Body: { conversation_id?: string, message: string }
+ * Returns: { conversation_id, message_id, response, memories_used }
+ */
+chatRouter.post('/', async (c) => {
+  const authUser = getAuthUser(c);
+  const body = await c.req.json<{ conversation_id?: string; message: string }>();
+
+  if (!body.message || typeof body.message !== 'string' || !body.message.trim()) {
+    return c.json({ error: 'Message is required' }, 400);
+  }
+
+  const client = getSupabaseClient();
+
+  // Ensure user profile exists
+  const userProfile = await ensureUserProfile(client, authUser.id, authUser.email);
+
+  let conversationId = body.conversation_id;
+
+  // If no conversation_id, create a new conversation with auto-title
+  if (!conversationId) {
+    const title = generateAutoTitle(body.message);
+    const conversation = await insertConversation(client, {
+      user_id: userProfile.id,
+      title,
+    });
+    conversationId = conversation.id;
+  } else {
+    // Verify user owns this conversation
+    const conversation = await getConversationById(client, conversationId);
+    if (!conversation) {
+      return c.json({ error: 'Conversation not found' }, 404);
+    }
+    if (conversation.user_id !== userProfile.id) {
+      return c.json({ error: 'Access denied' }, 403);
+    }
+  }
+
+  // Store user message
+  const userMsg = await insertMessage(client, {
+    conversation_id: conversationId,
+    user_id: userProfile.id,
+    role: 'user',
+    content: body.message.trim(),
+  });
+
+  // Generate memory-augmented response
+  const { text, memoriesUsed } = await generateChatResponse(
+    client,
+    body.message.trim(),
+    conversationId,
+    userProfile.id,
+  );
+
+  // Store assistant response
+  const assistantMsg = await insertMessage(client, {
+    conversation_id: conversationId,
+    user_id: userProfile.id,
+    role: 'assistant',
+    content: text,
+  });
+
+  // Update conversation message count (fire-and-forget)
+  updateConversationMessageCount(client, conversationId).catch((err) => {
+    console.error('Failed to update message count:', err instanceof Error ? err.message : err);
+  });
+
+  return c.json({
+    conversation_id: conversationId,
+    user_message_id: userMsg.id,
+    assistant_message_id: assistantMsg.id,
+    response: text,
+    memories_used: memoriesUsed,
+  });
+});
+
+/**
+ * GET /api/conversations — List user's conversations.
+ */
+conversationsRouter.get('/', async (c) => {
+  const authUser = getAuthUser(c);
+  const client = getSupabaseClient();
+
+  const userProfile = await ensureUserProfile(client, authUser.id, authUser.email);
+  const conversations = await getConversationsByUser(client, userProfile.id);
+
+  return c.json({ conversations });
+});
+
+/**
+ * POST /api/conversations — Create a new conversation.
+ *
+ * Body: { title?: string }
+ */
+conversationsRouter.post('/', async (c) => {
+  const authUser = getAuthUser(c);
+  const body = await c.req.json<{ title?: string }>();
+
+  const client = getSupabaseClient();
+  const userProfile = await ensureUserProfile(client, authUser.id, authUser.email);
+
+  const conversation = await insertConversation(client, {
+    user_id: userProfile.id,
+    title: body.title ?? null,
+  });
+
+  return c.json({ conversation }, 201);
+});
+
+/**
+ * GET /api/conversations/:id — Get a conversation with message history.
+ */
+conversationsRouter.get('/:id', async (c) => {
+  const authUser = getAuthUser(c);
+  const conversationId = c.req.param('id');
+  const client = getSupabaseClient();
+
+  const userProfile = await ensureUserProfile(client, authUser.id, authUser.email);
+
+  const conversation = await getConversationById(client, conversationId);
+  if (!conversation) {
+    return c.json({ error: 'Conversation not found' }, 404);
+  }
+
+  if (conversation.user_id !== userProfile.id) {
+    return c.json({ error: 'Access denied' }, 403);
+  }
+
+  const messages = await getMessagesByConversation(client, conversationId);
+
+  return c.json({ conversation, messages });
+});

--- a/guardian/src/llm/prompts.ts
+++ b/guardian/src/llm/prompts.ts
@@ -247,6 +247,53 @@ ${memoryLines.join('\n')}
 Synthesize a profile for this contributor based on their memories.`;
 }
 
+// -- Chat Prompts --
+
+export const CHAT_SYSTEM_PROMPT = `You are Guardian, an AI assistant with persistent memory. You remember everything users tell you across conversations. You manage the ai-continuity-framework repository and can discuss its methodology, architecture, and memory patterns. Be helpful, concise, and reference past conversations when relevant.
+
+When you have memory context, weave it naturally into your responses — don't list memories mechanically. If the user asks about something you have memories of, use them to give a more informed answer. If you don't have relevant context, just be helpful based on what the user says.
+
+Format your responses in Markdown when appropriate.`;
+
+/**
+ * Build a context block from retrieved memories and user profile
+ * for injection into the chat system prompt.
+ */
+export function buildChatContextBlock(
+  memories: { content: string; memory_type: string; topics: string[] | null }[],
+  userProfile?: {
+    display_name?: string | null;
+    summary?: string | null;
+    interests?: string[] | null;
+    communication_style?: string | null;
+  } | null,
+): string {
+  const sections: string[] = [];
+
+  if (userProfile) {
+    const profileLines: string[] = ['## User Context'];
+    if (userProfile.display_name) profileLines.push(`Name: ${userProfile.display_name}`);
+    if (userProfile.summary) profileLines.push(`Summary: ${userProfile.summary}`);
+    if (userProfile.interests?.length)
+      profileLines.push(`Interests: ${userProfile.interests.join(', ')}`);
+    if (userProfile.communication_style) {
+      profileLines.push(`Communication style: ${userProfile.communication_style}`);
+    }
+    sections.push(profileLines.join('\n'));
+  }
+
+  if (memories.length > 0) {
+    const memoryLines: string[] = ['## Relevant Memories'];
+    for (const mem of memories) {
+      const topicStr = mem.topics?.length ? ` [${mem.topics.join(', ')}]` : '';
+      memoryLines.push(`- (${mem.memory_type}${topicStr}) ${mem.content}`);
+    }
+    sections.push(memoryLines.join('\n'));
+  }
+
+  return sections.join('\n\n');
+}
+
 // -- Response Generation Prompts --
 
 export const RESPONSE_SYSTEM_PROMPT = `You are Guardian, an AI memory agent for the ai-continuity-framework GitHub repository.


### PR DESCRIPTION
## Summary

- **Chat endpoint** (`POST /api/chat`) — Send a message, get a memory-augmented response from Claude Sonnet with retrieved memories injected into the system prompt
- **Conversation management** — `GET/POST /api/conversations` and `GET /api/conversations/:id` for listing, creating, and viewing conversations with message history
- **Auto-title generation** — New conversations are automatically titled from the first message
- **Full auth enforcement** — All endpoints require Supabase JWT via `authMiddleware`, with ownership checks on conversation access

### Technical details
- Uses Retriever agent to fetch relevant memories for each user message
- Builds system prompt with `CHAT_SYSTEM_PROMPT` + memory context block + conversation history (last 20 messages)
- Calls Claude Sonnet (`claude-sonnet-4-6-20250514`) for response generation
- Stores both user and assistant messages in the `messages` table
- Fire-and-forget conversation message count updates

### New files
| File | Purpose |
|------|---------|
| `guardian/src/chat/router.ts` | Hono routers for `/api/chat` and `/api/conversations` |
| `guardian/src/chat/response.ts` | `generateChatResponse()`, `buildChatSystemPrompt()`, `generateAutoTitle()` |
| `guardian/src/__tests__/chat-api.test.ts` | 19 tests covering happy paths, auth, ownership, edge cases |

### Modified files
| File | Change |
|------|--------|
| `guardian/src/llm/prompts.ts` | Added `CHAT_SYSTEM_PROMPT` and `buildChatContextBlock()` |
| `guardian/src/app.ts` | Mounted chat and conversations routers |

## Test plan

- [x] POST /api/chat: sends message, gets response with memory context
- [x] POST /api/chat: creates new conversation when no conversation_id provided
- [x] POST /api/chat: appends to existing conversation
- [x] POST /api/chat: rejects unauthenticated requests (401)
- [x] POST /api/chat: stores both user and assistant messages
- [x] POST /api/chat: rejects empty message (400)
- [x] POST /api/chat: returns 404 for non-existent conversation
- [x] POST /api/chat: returns 403 for another user's conversation
- [x] GET /api/conversations: returns user's conversations
- [x] GET /api/conversations: rejects unauthenticated (401)
- [x] POST /api/conversations: creates with title
- [x] POST /api/conversations: creates without title
- [x] GET /api/conversations/:id: returns conversation with messages
- [x] GET /api/conversations/:id: rejects access to other user's conversations
- [x] GET /api/conversations/:id: returns 404 for non-existent
- [x] Response generation includes retrieved memories in context
- [x] Auto-title generated from first message (with truncation and sentence splitting)
- [x] Sacred Four: typecheck, lint, test (192 passing), build — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)