### PR TITLE
feat(guardian): Scribe Agent — conversation memory extraction

### DIFF
--- a/guardian/src/__tests__/scribe.test.ts
+++ b/guardian/src/__tests__/scribe.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message } from '../db/schema.js';
+
+// -- Hoisted mock state --
+
+const mockState = vi.hoisted(() => ({
+  insertedMemories: [] as Record<string, unknown>[],
+  processedMessageIds: [] as string[],
+  agentStateUpserts: [] as Record<string, unknown>[],
+  llmCallCount: 0,
+  llmShouldFail: false,
+  embeddingShouldFail: false,
+  unprocessedMessages: [] as Message[],
+  conversationMessages: [] as Message[],
+}));
+
+// -- Mock LLM client --
+
+vi.mock('../llm/client.js', () => ({
+  getAnthropicClient: vi.fn(() => ({
+    messages: {
+      create: vi.fn(async () => {
+        mockState.llmCallCount++;
+        if (mockState.llmShouldFail) {
+          throw new Error('LLM API error');
+        }
+        return {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool-call-001',
+              name: 'extract_memories',
+              input: {
+                memories: [
+                  {
+                    content: 'User prefers dark mode for all their applications.',
+                    memory_type: 'preference',
+                    topics: ['personal-preference', 'ui-settings'],
+                    entities: ['user-001'],
+                    importance_score: 0.5,
+                    confidence_score: 0.9,
+                    source_type: 'stated',
+                    emotional_valence: 0.2,
+                    emotional_arousal: 0.1,
+                  },
+                  {
+                    content:
+                      'User decided to migrate their project to TypeScript for better type safety.',
+                    memory_type: 'decision',
+                    topics: ['project-migration', 'typescript'],
+                    entities: ['user-001', 'typescript'],
+                    importance_score: 0.7,
+                    confidence_score: 0.85,
+                    source_type: 'stated',
+                    emotional_valence: null,
+                    emotional_arousal: null,
+                  },
+                ],
+              },
+            },
+          ],
+        };
+      }),
+    },
+  })),
+  getOpenAIClient: vi.fn(),
+  resetLLMClients: vi.fn(),
+}));
+
+// -- Mock embeddings --
+
+vi.mock('../llm/embeddings.js', () => ({
+  generateEmbedding: vi.fn(async () => {
+    if (mockState.embeddingShouldFail) {
+      return null;
+    }
+    return Array.from({ length: 1536 }, (_, i) => i * 0.001);
+  }),
+}));
+
+// -- Mock DB --
+
+vi.mock('../db/client.js', () => ({
+  getSupabaseClient: vi.fn(() => ({})),
+}));
+
+vi.mock('../db/queries.js', () => ({
+  getUnprocessedMessages: vi.fn(async () => mockState.unprocessedMessages),
+  getMessagesByConversation: vi.fn(async () => mockState.conversationMessages),
+  markMessageProcessed: vi.fn(async (_client: unknown, messageId: string) => {
+    mockState.processedMessageIds.push(messageId);
+  }),
+  insertExtractedMemory: vi.fn(async (_client: unknown, memory: Record<string, unknown>) => {
+    mockState.insertedMemories.push(memory);
+    return { ...memory, id: `mem-${mockState.insertedMemories.length}` };
+  }),
+  upsertAgentState: vi.fn(async (_client: unknown, state: Record<string, unknown>) => {
+    mockState.agentStateUpserts.push(state);
+    return state;
+  }),
+}));
+
+// Import after mocks
+import { runScribe } from '../agents/scribe.js';
+import { getUnprocessedMessages } from '../db/queries.js';
+
+// -- Fixtures --
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'msg-001',
+    conversation_id: 'conv-001',
+    user_id: 'user-001',
+    role: 'user',
+    content: 'I really prefer dark mode in all my apps. Also, I decided to migrate to TypeScript.',
+    processed: false,
+    processed_at: null,
+    created_at: '2026-03-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+const REPO_ID = 'leonardrknight/ai-continuity-framework';
+
+describe('Scribe Agent', () => {
+  beforeEach(() => {
+    mockState.insertedMemories = [];
+    mockState.processedMessageIds = [];
+    mockState.agentStateUpserts = [];
+    mockState.llmCallCount = 0;
+    mockState.llmShouldFail = false;
+    mockState.embeddingShouldFail = false;
+    mockState.unprocessedMessages = [makeMessage()];
+    mockState.conversationMessages = [makeMessage()];
+  });
+
+  it('extracts memories from conversation messages', async () => {
+    const result = await runScribe({} as never, REPO_ID);
+
+    expect(result.messagesProcessed).toBe(1);
+    expect(result.memoriesCreated).toBe(2);
+    expect(result.errors).toBe(0);
+
+    const mem1 = mockState.insertedMemories[0];
+    expect(mem1.memory_type).toBe('preference');
+    expect(mem1.topics).toContain('personal-preference');
+    expect(mem1.content).toContain('dark mode');
+  });
+
+  it('sets source_message_id (not source_event_id) on extracted memories', async () => {
+    await runScribe({} as never, REPO_ID);
+
+    for (const mem of mockState.insertedMemories) {
+      expect(mem.source_message_id).toBe('msg-001');
+      expect(mem).not.toHaveProperty('source_event_id');
+    }
+  });
+
+  it('sets user_id on extracted memories', async () => {
+    await runScribe({} as never, REPO_ID);
+
+    for (const mem of mockState.insertedMemories) {
+      expect(mem.user_id).toBe('user-001');
+    }
+  });
+
+  it('sets source_channel to conversation', async () => {
+    await runScribe({} as never, REPO_ID);
+
+    for (const mem of mockState.insertedMemories) {
+      expect(mem.source_channel).toBe('conversation');
+    }
+  });
+
+  it('groups messages by conversation and processes each batch', async () => {
+    mockState.unprocessedMessages = [
+      makeMessage({ id: 'msg-001', conversation_id: 'conv-001' }),
+      makeMessage({ id: 'msg-002', conversation_id: 'conv-001' }),
+      makeMessage({ id: 'msg-003', conversation_id: 'conv-002' }),
+    ];
+    mockState.conversationMessages = [
+      makeMessage({ id: 'msg-001', conversation_id: 'conv-001' }),
+      makeMessage({ id: 'msg-002', conversation_id: 'conv-001' }),
+    ];
+
+    const result = await runScribe({} as never, REPO_ID);
+
+    // Two conversations processed = 2 LLM calls
+    expect(mockState.llmCallCount).toBe(2);
+    expect(result.messagesProcessed).toBe(3);
+    // 2 memories per LLM call x 2 conversations = 4
+    expect(result.memoriesCreated).toBe(4);
+  });
+
+  it('generates embeddings for each memory', async () => {
+    await runScribe({} as never, REPO_ID);
+
+    for (const mem of mockState.insertedMemories) {
+      expect(mem.content_embedding).toBeDefined();
+      expect(Array.isArray(mem.content_embedding)).toBe(true);
+      expect((mem.content_embedding as number[]).length).toBe(1536);
+    }
+  });
+
+  it('stores without embedding on embedding failure', async () => {
+    mockState.embeddingShouldFail = true;
+
+    const result = await runScribe({} as never, REPO_ID);
+
+    expect(result.memoriesCreated).toBe(2);
+    for (const mem of mockState.insertedMemories) {
+      expect(mem.content_embedding).toBeNull();
+    }
+  });
+
+  it('marks messages as processed', async () => {
+    mockState.unprocessedMessages = [
+      makeMessage({ id: 'msg-001' }),
+      makeMessage({ id: 'msg-002' }),
+    ];
+
+    await runScribe({} as never, REPO_ID);
+
+    expect(mockState.processedMessageIds).toContain('msg-001');
+    expect(mockState.processedMessageIds).toContain('msg-002');
+  });
+
+  it('processes both user and assistant messages', async () => {
+    mockState.unprocessedMessages = [
+      makeMessage({ id: 'msg-user', role: 'user', content: 'I prefer dark mode.' }),
+      makeMessage({
+        id: 'msg-assistant',
+        role: 'assistant',
+        content: 'I will remember your dark mode preference.',
+      }),
+    ];
+
+    const result = await runScribe({} as never, REPO_ID);
+
+    // Both messages should be processed (grouped by conversation, sent together)
+    expect(result.messagesProcessed).toBe(2);
+    expect(mockState.processedMessageIds).toContain('msg-user');
+    expect(mockState.processedMessageIds).toContain('msg-assistant');
+  });
+
+  it('updates agent_state with scribe stats', async () => {
+    await runScribe({} as never, REPO_ID);
+
+    expect(mockState.agentStateUpserts.length).toBe(1);
+    const state = mockState.agentStateUpserts[0];
+    expect(state.agent_name).toBe('scribe');
+    expect(state.repo_id).toBe(REPO_ID);
+    expect(state.items_processed).toBe(1);
+    expect(state.last_run_at).toBeDefined();
+    expect(state.last_successful_at).toBeDefined();
+    const metadata = state.metadata as Record<string, unknown>;
+    expect(metadata.last_run_memories_created).toBe(2);
+    expect(metadata.last_run_messages_processed).toBe(1);
+    expect(metadata.last_run_errors).toBe(0);
+  });
+
+  it('returns early when no unprocessed messages', async () => {
+    vi.mocked(getUnprocessedMessages).mockResolvedValueOnce([]);
+
+    const result = await runScribe({} as never, REPO_ID);
+
+    expect(result.messagesProcessed).toBe(0);
+    expect(result.memoriesCreated).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(mockState.agentStateUpserts.length).toBe(0);
+  });
+
+  it('handles LLM extraction failure gracefully', async () => {
+    mockState.llmShouldFail = true;
+
+    const result = await runScribe({} as never, REPO_ID);
+
+    expect(result.errors).toBe(1);
+    expect(result.messagesProcessed).toBe(0);
+    expect(result.memoriesCreated).toBe(0);
+    // Messages should NOT be marked processed (will retry next run)
+    expect(mockState.processedMessageIds).not.toContain('msg-001');
+  });
+
+  it('extracts emotional context (valence + arousal)', async () => {
+    await runScribe({} as never, REPO_ID);
+
+    // First memory has emotional data
+    const mem1 = mockState.insertedMemories[0];
+    expect(mem1.emotional_valence).toBe(0.2);
+    expect(mem1.emotional_arousal).toBe(0.1);
+
+    // Second memory has null emotional data
+    const mem2 = mockState.insertedMemories[1];
+    expect(mem2.emotional_valence).toBeNull();
+    expect(mem2.emotional_arousal).toBeNull();
+  });
+});

--- a/guardian/src/agents/scribe.ts
+++ b/guardian/src/agents/scribe.ts
@@ -1,0 +1,220 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getAnthropicClient } from '../llm/client.js';
+import {
+  CONVERSATION_EXTRACTION_PROMPT,
+  CONVERSATION_EXTRACTION_TOOL_SCHEMA,
+  buildConversationExtractionMessage,
+  type ExtractedMemoryLLM,
+} from '../llm/prompts.js';
+import { generateEmbedding } from '../llm/embeddings.js';
+import {
+  getUnprocessedMessages,
+  getMessagesByConversation,
+  markMessageProcessed,
+  insertExtractedMemory,
+  upsertAgentState,
+} from '../db/queries.js';
+import type { Message, ExtractedMemoryInsert } from '../db/schema.js';
+
+const EXTRACTION_MODEL = 'claude-haiku-4-5-20251001';
+const MAX_LLM_RETRIES = 3;
+const BATCH_SIZE = 30;
+const CONTEXT_WINDOW = 10;
+
+/** Result from a single scribe run. */
+export interface ScribeRunResult {
+  messagesProcessed: number;
+  memoriesCreated: number;
+  errors: number;
+}
+
+/**
+ * Group messages by conversation_id.
+ */
+function groupByConversation(messages: Message[]): Map<string, Message[]> {
+  const groups = new Map<string, Message[]>();
+  for (const msg of messages) {
+    const existing = groups.get(msg.conversation_id);
+    if (existing) {
+      existing.push(msg);
+    } else {
+      groups.set(msg.conversation_id, [msg]);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Call the LLM to extract memories from a batch of conversation messages.
+ */
+async function callConversationExtractionLLM(
+  messages: { role: string; content: string }[],
+  username: string,
+): Promise<ExtractedMemoryLLM[]> {
+  const anthropic = getAnthropicClient();
+  const userMessage = buildConversationExtractionMessage(messages, username);
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_LLM_RETRIES; attempt++) {
+    try {
+      const response = await anthropic.messages.create({
+        model: EXTRACTION_MODEL,
+        max_tokens: 2048,
+        system: CONVERSATION_EXTRACTION_PROMPT,
+        tools: [CONVERSATION_EXTRACTION_TOOL_SCHEMA],
+        tool_choice: { type: 'tool', name: 'extract_memories' },
+        messages: [{ role: 'user', content: userMessage }],
+      });
+
+      const toolBlock = response.content.find((block) => block.type === 'tool_use');
+      if (!toolBlock || toolBlock.type !== 'tool_use') {
+        throw new Error('No tool_use block in LLM response');
+      }
+
+      const input = toolBlock.input as { memories: ExtractedMemoryLLM[] };
+      return input.memories ?? [];
+    } catch (error) {
+      lastError = error;
+      if (attempt < MAX_LLM_RETRIES - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * Math.pow(2, attempt)));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Process a conversation batch: extract memories from messages, generate embeddings, store results.
+ * Returns the number of memories created.
+ */
+async function processConversationBatch(
+  client: SupabaseClient,
+  batchMessages: Message[],
+  contextMessages: { role: string; content: string }[],
+  repoId: string,
+): Promise<number> {
+  // Combine context messages with current batch for thread awareness
+  const batchForExtraction = batchMessages.map((m) => ({
+    role: m.role,
+    content: m.content,
+  }));
+
+  // Use context + batch, but only extract from the batch portion
+  const allMessages = [...contextMessages, ...batchForExtraction];
+
+  // Get username from the first user message in the batch
+  const username = batchMessages[0]?.user_id ?? 'unknown';
+
+  // Extract memories via LLM
+  const memories = await callConversationExtractionLLM(allMessages, username);
+
+  // Store each extracted memory
+  let created = 0;
+  for (const memory of memories) {
+    // Generate embedding (null on failure)
+    const embedding = await generateEmbedding(memory.content);
+
+    // Link to the first message in the batch as the source
+    const insert: ExtractedMemoryInsert = {
+      source_message_id: batchMessages[0].id,
+      user_id: batchMessages[0].user_id,
+      repo_id: repoId,
+      content: memory.content,
+      content_embedding: embedding,
+      memory_type: memory.memory_type,
+      topics: memory.topics,
+      entities: memory.entities,
+      importance_score: memory.importance_score,
+      confidence_score: memory.confidence_score,
+      source_type: memory.source_type,
+      source_channel: 'conversation',
+      emotional_valence: memory.emotional_valence,
+      emotional_arousal: memory.emotional_arousal,
+    };
+
+    await insertExtractedMemory(client, insert);
+    created++;
+  }
+
+  return created;
+}
+
+/**
+ * Run the scribe agent: fetch unprocessed messages, extract memories, store results.
+ * This is the core function called by the Inngest cron job.
+ */
+export async function runScribe(client: SupabaseClient, repoId: string): Promise<ScribeRunResult> {
+  const result: ScribeRunResult = {
+    messagesProcessed: 0,
+    memoriesCreated: 0,
+    errors: 0,
+  };
+
+  const messages = await getUnprocessedMessages(client, BATCH_SIZE);
+  if (messages.length === 0) {
+    return result;
+  }
+
+  // Group messages by conversation for thread awareness
+  const conversationGroups = groupByConversation(messages);
+
+  for (const [conversationId, batchMessages] of conversationGroups) {
+    try {
+      // Get recent conversation context (last N messages for thread awareness)
+      const recentMessages = await getMessagesByConversation(
+        client,
+        conversationId,
+        CONTEXT_WINDOW,
+      );
+
+      // Build context from already-processed messages (exclude current batch)
+      const batchIds = new Set(batchMessages.map((m) => m.id));
+      const contextMessages = recentMessages
+        .filter((m) => !batchIds.has(m.id))
+        .map((m) => ({ role: m.role, content: m.content }));
+
+      const created = await processConversationBatch(
+        client,
+        batchMessages,
+        contextMessages,
+        repoId,
+      );
+
+      result.memoriesCreated += created;
+
+      // Mark all batch messages as processed
+      for (const msg of batchMessages) {
+        await markMessageProcessed(client, msg.id);
+        result.messagesProcessed++;
+      }
+    } catch (error) {
+      result.errors++;
+      console.error(
+        `Scribe failed for conversation ${conversationId}:`,
+        error instanceof Error ? error.message : error,
+      );
+      // Messages stay unprocessed — will be retried on next run
+    }
+  }
+
+  // Update agent state
+  await upsertAgentState(client, {
+    agent_name: 'scribe',
+    repo_id: repoId,
+    last_run_at: new Date().toISOString(),
+    ...(result.errors === 0 ? { last_successful_at: new Date().toISOString() } : {}),
+    items_processed: result.messagesProcessed,
+    error_count_24h: result.errors,
+    ...(result.errors > 0
+      ? { last_error: `${result.errors} conversations failed in last run` }
+      : { last_error: null }),
+    metadata: {
+      last_run_memories_created: result.memoriesCreated,
+      last_run_messages_processed: result.messagesProcessed,
+      last_run_errors: result.errors,
+    },
+  });
+
+  return result;
+}

--- a/guardian/src/app.ts
+++ b/guardian/src/app.ts
@@ -11,6 +11,7 @@ import { inngest } from './inngest/client.js';
 import { extractorCron } from './inngest/functions/extractor.js';
 import { consolidatorCron } from './inngest/functions/consolidator.js';
 import { curatorCron } from './inngest/functions/curator.js';
+import { scribeCron } from './inngest/functions/scribe.js';
 import { responderHandler } from './inngest/functions/responder.js';
 import { chatRouter, conversationsRouter } from './chat/router.js';
 
@@ -26,7 +27,7 @@ app.on(
   '/api/inngest',
   serveInngest({
     client: inngest,
-    functions: [extractorCron, consolidatorCron, curatorCron, responderHandler],
+    functions: [extractorCron, consolidatorCron, curatorCron, scribeCron, responderHandler],
   }),
 );
 

--- a/guardian/src/inngest/functions/scribe.ts
+++ b/guardian/src/inngest/functions/scribe.ts
@@ -1,0 +1,26 @@
+import { inngest } from '../client.js';
+import { getSupabaseClient } from '../../db/client.js';
+import { loadConfig } from '../../config.js';
+import { runScribe } from '../../agents/scribe.js';
+
+/**
+ * Inngest cron function: runs every 2 minutes to process unprocessed conversation messages.
+ */
+export const scribeCron = inngest.createFunction(
+  {
+    id: 'scribe-cron',
+    name: 'Scribe Agent — Process Conversation Messages',
+  },
+  { cron: '*/2 * * * *' },
+  async () => {
+    const config = loadConfig();
+    const client = getSupabaseClient();
+    const result = await runScribe(client, config.GUARDIAN_REPO);
+
+    console.log(
+      `Scribe run complete: ${result.messagesProcessed} messages, ${result.memoriesCreated} memories, ${result.errors} errors`,
+    );
+
+    return result;
+  },
+);

--- a/guardian/src/llm/prompts.ts
+++ b/guardian/src/llm/prompts.ts
@@ -294,6 +294,41 @@ export function buildChatContextBlock(
   return sections.join('\n\n');
 }
 
+// -- Conversation Extraction Prompts (Scribe Agent) --
+
+export const CONVERSATION_EXTRACTION_PROMPT = `You are a memory extraction agent processing conversation turns. Extract structured memories that capture important information the user has shared — facts about themselves, decisions they've made, preferences they've expressed, questions they've asked, relationships they've mentioned, and patterns in how they communicate.
+
+Also extract important information from assistant responses — decisions made, recommendations given, explanations provided, and commitments made.
+
+Guidelines:
+- Extract facts, decisions, preferences, patterns, questions, action items, and relationships
+- Assign importance_score (0-1): casual chat ~0.2, personal preferences ~0.5, important decisions ~0.8, life events ~0.9
+- Assign confidence_score (0-1): explicit statements ~0.9, inferred patterns ~0.6
+- source_type: "stated" for explicit content, "inferred" for implied meaning
+- emotional_valence (-1 to 1): negative sentiment = -1, neutral = 0, positive = 1. null if no emotional content.
+- emotional_arousal (0 to 1): calm = 0, highly energetic = 1. null if no emotional content.
+- Topics should be lowercase, hyphenated (e.g., "personal-preference", "project-decision")
+- Entities should be usernames, names, file paths, or concept names
+- Skip trivial messages like "ok", "thanks", simple greetings with no substance
+- If the conversation has no meaningful content to extract, return an empty array`;
+
+export const CONVERSATION_EXTRACTION_TOOL_SCHEMA: Anthropic.Tool = EXTRACTION_TOOL_SCHEMA;
+
+/** Format conversation messages for extraction by the Scribe agent. */
+export function buildConversationExtractionMessage(
+  messages: { role: string; content: string }[],
+  username: string,
+): string {
+  const formatted = messages.map((m) => {
+    const speaker = m.role === 'user' ? `User (${username})` : 'Assistant';
+    return `${speaker}: ${m.content}`;
+  });
+
+  return `Conversation with ${username}:
+
+${formatted.join('\n\n')}`;
+}
+
 // -- Response Generation Prompts --
 
 export const RESPONSE_SYSTEM_PROMPT = `You are Guardian, an AI memory agent for the ai-continuity-framework GitHub repository.


### PR DESCRIPTION
## Summary
- Adds the Scribe Agent — real-time extraction of structured memories from conversation turns (both user and assistant messages)
- Mirrors the Extractor pattern but adapted for conversational input: groups messages by conversation, includes thread context for better extraction, sets `source_message_id`/`user_id`/`source_channel: 'conversation'`
- Includes conversation extraction prompt, Inngest cron (every 2 minutes), and 13 new tests (205 total, all passing)

## What's included
- `guardian/src/agents/scribe.ts` — Core scribe pipeline with conversation grouping, context windowing, LLM extraction, embedding generation
- `guardian/src/llm/prompts.ts` — `CONVERSATION_EXTRACTION_PROMPT`, `CONVERSATION_EXTRACTION_TOOL_SCHEMA`, `buildConversationExtractionMessage()`
- `guardian/src/inngest/functions/scribe.ts` — `scribeCron` (every 2 minutes)
- `guardian/src/app.ts` — Wired `scribeCron` into Inngest serve
- `guardian/src/__tests__/scribe.test.ts` — 13 tests covering extraction, field mapping, grouping, embeddings, error handling, emotional context

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (205 tests, 0 failures)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)