### PR TITLE
feat(guardian): Web chat UI

### DIFF
--- a/guardian/.env.example
+++ b/guardian/.env.example
@@ -9,6 +9,8 @@ GITHUB_INSTALLATION_TOKEN=
 SUPABASE_URL=https://effzofflphvbyvcenvly.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_ANON_KEY=
+# SUPABASE_URL and SUPABASE_ANON_KEY are also served to the frontend via GET /api/config
+# These are public keys — safe to expose to browsers
 
 # Anthropic
 ANTHROPIC_API_KEY=

--- a/guardian/public/app.js
+++ b/guardian/public/app.js
@@ -1,0 +1,422 @@
+/**
+ * Guardian Chat UI — Client-side application
+ *
+ * Handles Supabase Auth, conversation management, and chat messaging.
+ * No frameworks — vanilla JS with Supabase CDN client.
+ */
+
+(function () {
+  'use strict';
+
+  // ─── State ───
+  let supabase = null;
+  let session = null;
+  let conversations = [];
+  let activeConversationId = null;
+  let isSending = false;
+
+  // ─── DOM References ───
+  const authScreen = document.getElementById('auth-screen');
+  const chatScreen = document.getElementById('chat-screen');
+  const authForm = document.getElementById('auth-form');
+  const authEmail = document.getElementById('auth-email');
+  const authPassword = document.getElementById('auth-password');
+  const authSubmit = document.getElementById('auth-submit');
+  const authError = document.getElementById('auth-error');
+  const authTabs = document.querySelectorAll('.auth-tab');
+  const sidebar = document.getElementById('sidebar');
+  const sidebarOverlay = document.getElementById('sidebar-overlay');
+  const conversationList = document.getElementById('conversation-list');
+  const newChatBtn = document.getElementById('new-chat-btn');
+  const userEmailEl = document.getElementById('user-email');
+  const logoutBtn = document.getElementById('logout-btn');
+  const chatTitle = document.getElementById('chat-title');
+  const messagesContainer = document.getElementById('messages-container');
+  const emptyState = document.getElementById('empty-state');
+  const typingIndicator = document.getElementById('typing-indicator');
+  const messageInput = document.getElementById('message-input');
+  const sendBtn = document.getElementById('send-btn');
+  const mobileMenuBtn = document.getElementById('mobile-menu-btn');
+
+  let authMode = 'login'; // 'login' | 'signup'
+
+  // ─── Init ───
+
+  async function init() {
+    try {
+      const res = await fetch('/api/config');
+      if (!res.ok) throw new Error('Failed to load config');
+      const config = await res.json();
+
+      supabase = window.supabase.createClient(config.supabaseUrl, config.supabaseAnonKey);
+
+      // Check for existing session
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        session = data.session;
+        showChat();
+      }
+
+      // Listen for auth state changes
+      supabase.auth.onAuthStateChange((_event, newSession) => {
+        session = newSession;
+        if (session) {
+          showChat();
+        } else {
+          showAuth();
+        }
+      });
+    } catch (err) {
+      console.error('Init failed:', err);
+      showAuthError('Failed to connect. Please refresh.');
+    }
+
+    bindEvents();
+  }
+
+  // ─── Auth ───
+
+  function bindEvents() {
+    // Auth tabs
+    authTabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        authMode = tab.dataset.tab;
+        authTabs.forEach((t) => t.classList.toggle('active', t.dataset.tab === authMode));
+        authSubmit.textContent = authMode === 'login' ? 'Log in' : 'Sign up';
+        authPassword.autocomplete = authMode === 'login' ? 'current-password' : 'new-password';
+        showAuthError('');
+      });
+    });
+
+    // Auth form submit
+    authForm.addEventListener('submit', handleAuth);
+
+    // Logout
+    logoutBtn.addEventListener('click', handleLogout);
+
+    // New conversation
+    newChatBtn.addEventListener('click', startNewConversation);
+
+    // Send message
+    sendBtn.addEventListener('click', handleSend);
+
+    // Message input
+    messageInput.addEventListener('input', handleInputChange);
+    messageInput.addEventListener('keydown', handleInputKeydown);
+
+    // Mobile sidebar
+    mobileMenuBtn.addEventListener('click', () => sidebar.classList.add('open'));
+    sidebarOverlay.addEventListener('click', closeSidebar);
+
+    // Escape to close sidebar
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') closeSidebar();
+    });
+  }
+
+  async function handleAuth(e) {
+    e.preventDefault();
+    showAuthError('');
+    authSubmit.disabled = true;
+
+    const email = authEmail.value.trim();
+    const password = authPassword.value;
+
+    try {
+      let result;
+      if (authMode === 'login') {
+        result = await supabase.auth.signInWithPassword({ email, password });
+      } else {
+        result = await supabase.auth.signUp({ email, password });
+      }
+
+      if (result.error) {
+        showAuthError(result.error.message);
+      } else if (authMode === 'signup' && result.data.user && !result.data.session) {
+        showAuthError('Check your email to confirm your account.');
+      }
+    } catch (err) {
+      showAuthError('An unexpected error occurred.');
+    } finally {
+      authSubmit.disabled = false;
+    }
+  }
+
+  async function handleLogout() {
+    await supabase.auth.signOut();
+    session = null;
+    conversations = [];
+    activeConversationId = null;
+    showAuth();
+  }
+
+  function showAuthError(msg) {
+    authError.textContent = msg || '';
+  }
+
+  // ─── Screen Switching ───
+
+  function showAuth() {
+    authScreen.style.display = 'flex';
+    chatScreen.classList.remove('visible');
+    authForm.reset();
+    showAuthError('');
+  }
+
+  function showChat() {
+    authScreen.style.display = 'none';
+    chatScreen.classList.add('visible');
+    userEmailEl.textContent = session?.user?.email || '';
+    loadConversations();
+  }
+
+  // ─── Conversations ───
+
+  async function loadConversations() {
+    try {
+      const res = await apiFetch('/api/conversations');
+      if (!res.ok) throw new Error('Failed to load conversations');
+      const data = await res.json();
+      conversations = data.conversations || [];
+      renderConversationList();
+    } catch (err) {
+      console.error('Load conversations failed:', err);
+    }
+  }
+
+  function renderConversationList() {
+    conversationList.innerHTML = '';
+
+    if (conversations.length === 0) {
+      conversationList.innerHTML =
+        '<div style="padding: 1rem; color: var(--text-muted); font-size: 0.8rem; text-align: center;">No conversations yet</div>';
+      return;
+    }
+
+    conversations.forEach((conv) => {
+      const item = document.createElement('div');
+      item.className = 'conversation-item' + (conv.id === activeConversationId ? ' active' : '');
+      item.dataset.id = conv.id;
+
+      const title = document.createElement('div');
+      title.className = 'conversation-item-title';
+      title.textContent = conv.title || 'Untitled';
+
+      const meta = document.createElement('div');
+      meta.className = 'conversation-item-meta';
+      meta.textContent = formatRelativeTime(conv.updated_at || conv.created_at);
+
+      item.appendChild(title);
+      item.appendChild(meta);
+
+      item.addEventListener('click', () => {
+        selectConversation(conv.id);
+        closeSidebar();
+      });
+
+      conversationList.appendChild(item);
+    });
+  }
+
+  async function selectConversation(id) {
+    activeConversationId = id;
+    renderConversationList();
+
+    const conv = conversations.find((c) => c.id === id);
+    chatTitle.textContent = conv?.title || 'Guardian';
+
+    // Load messages
+    try {
+      const res = await apiFetch('/api/conversations/' + id);
+      if (!res.ok) throw new Error('Failed to load messages');
+      const data = await res.json();
+      renderMessages(data.messages || []);
+    } catch (err) {
+      console.error('Load messages failed:', err);
+    }
+  }
+
+  function startNewConversation() {
+    activeConversationId = null;
+    chatTitle.textContent = 'New conversation';
+    clearMessages();
+    closeSidebar();
+    messageInput.focus();
+  }
+
+  // ─── Messages ───
+
+  function renderMessages(messages) {
+    clearMessages();
+    if (messages.length === 0) return;
+
+    emptyState.style.display = 'none';
+    messages.forEach((msg) => appendMessage(msg.role, msg.content));
+    scrollToBottom();
+  }
+
+  function clearMessages() {
+    // Remove all messages but keep empty state
+    const msgElements = messagesContainer.querySelectorAll('.message');
+    msgElements.forEach((el) => el.remove());
+    emptyState.style.display = 'flex';
+  }
+
+  function appendMessage(role, content) {
+    emptyState.style.display = 'none';
+
+    const msgEl = document.createElement('div');
+    msgEl.className = 'message ' + role;
+
+    const avatar = document.createElement('div');
+    avatar.className = 'message-avatar';
+    avatar.textContent = role === 'assistant' ? 'G' : 'U';
+
+    const bubble = document.createElement('div');
+    bubble.className = 'message-bubble';
+    bubble.textContent = content;
+
+    msgEl.appendChild(avatar);
+    msgEl.appendChild(bubble);
+
+    messagesContainer.appendChild(msgEl);
+    scrollToBottom();
+  }
+
+  function scrollToBottom() {
+    requestAnimationFrame(() => {
+      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    });
+  }
+
+  function showTyping() {
+    typingIndicator.classList.add('visible');
+    scrollToBottom();
+  }
+
+  function hideTyping() {
+    typingIndicator.classList.remove('visible');
+  }
+
+  // ─── Send Message ───
+
+  async function handleSend() {
+    const text = messageInput.value.trim();
+    if (!text || isSending) return;
+
+    isSending = true;
+    sendBtn.disabled = true;
+    messageInput.value = '';
+    autoResize();
+
+    appendMessage('user', text);
+    showTyping();
+
+    try {
+      const body = { message: text };
+      if (activeConversationId) {
+        body.conversation_id = activeConversationId;
+      }
+
+      const res = await apiFetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      hideTyping();
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Request failed' }));
+        appendMessage('assistant', 'Error: ' + (err.error || 'Something went wrong.'));
+        return;
+      }
+
+      const data = await res.json();
+
+      // If this was a new conversation, update state
+      if (!activeConversationId && data.conversation_id) {
+        activeConversationId = data.conversation_id;
+        await loadConversations();
+        // Update active highlight
+        renderConversationList();
+        const conv = conversations.find((c) => c.id === activeConversationId);
+        chatTitle.textContent = conv?.title || 'Guardian';
+      }
+
+      appendMessage('assistant', data.response);
+    } catch (err) {
+      hideTyping();
+      appendMessage('assistant', 'Error: Failed to send message. Please try again.');
+      console.error('Send failed:', err);
+    } finally {
+      isSending = false;
+      updateSendButton();
+      messageInput.focus();
+    }
+  }
+
+  // ─── Input Handling ───
+
+  function handleInputChange() {
+    updateSendButton();
+    autoResize();
+  }
+
+  function handleInputKeydown(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  function updateSendButton() {
+    sendBtn.disabled = !messageInput.value.trim() || isSending;
+  }
+
+  function autoResize() {
+    messageInput.style.height = 'auto';
+    messageInput.style.height = Math.min(messageInput.scrollHeight, 150) + 'px';
+  }
+
+  // ─── Mobile Sidebar ───
+
+  function closeSidebar() {
+    sidebar.classList.remove('open');
+  }
+
+  // ─── API Helper ───
+
+  async function apiFetch(url, options = {}) {
+    const token = session?.access_token;
+    const headers = {
+      ...(options.headers || {}),
+    };
+    if (token) {
+      headers['Authorization'] = 'Bearer ' + token;
+    }
+    return fetch(url, { ...options, headers });
+  }
+
+  // ─── Utilities ───
+
+  function formatRelativeTime(isoStr) {
+    if (!isoStr) return '';
+    const date = new Date(isoStr);
+    const now = new Date();
+    const diffMs = now - date;
+    const diffMin = Math.floor(diffMs / 60000);
+    const diffHr = Math.floor(diffMs / 3600000);
+    const diffDay = Math.floor(diffMs / 86400000);
+
+    if (diffMin < 1) return 'just now';
+    if (diffMin < 60) return diffMin + 'm ago';
+    if (diffHr < 24) return diffHr + 'h ago';
+    if (diffDay < 7) return diffDay + 'd ago';
+
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  }
+
+  // ─── Start ───
+  init();
+})();

--- a/guardian/public/index.html
+++ b/guardian/public/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Guardian</title>
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+</head>
+<body>
+
+  <!-- Auth Screen -->
+  <div id="auth-screen">
+    <div class="auth-container">
+      <div class="auth-header">
+        <div class="auth-logo">Guardian</div>
+        <div class="auth-subtitle">AI memory &amp; continuity agent</div>
+      </div>
+      <div class="auth-card">
+        <div class="auth-tabs">
+          <button class="auth-tab active" data-tab="login">Log in</button>
+          <button class="auth-tab" data-tab="signup">Sign up</button>
+        </div>
+        <form id="auth-form" class="auth-form" autocomplete="on">
+          <div class="form-group">
+            <label for="auth-email">Email</label>
+            <input type="email" id="auth-email" name="email" required placeholder="you@example.com" autocomplete="email">
+          </div>
+          <div class="form-group">
+            <label for="auth-password">Password</label>
+            <input type="password" id="auth-password" name="password" required placeholder="Enter password" minlength="6" autocomplete="current-password">
+          </div>
+          <button type="submit" class="auth-btn" id="auth-submit">Log in</button>
+          <div class="auth-error" id="auth-error"></div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Chat Screen -->
+  <div id="chat-screen">
+    <!-- Sidebar -->
+    <aside class="sidebar" id="sidebar">
+      <div class="sidebar-header">
+        <span class="sidebar-title">Guardian</span>
+        <button class="new-chat-btn" id="new-chat-btn" title="New conversation">+</button>
+      </div>
+      <div class="conversation-list" id="conversation-list"></div>
+      <div class="sidebar-footer">
+        <div class="user-info">
+          <span class="user-email" id="user-email"></span>
+          <button class="logout-btn" id="logout-btn">Log out</button>
+        </div>
+      </div>
+    </aside>
+    <div class="sidebar-overlay" id="sidebar-overlay"></div>
+
+    <!-- Chat Area -->
+    <main class="chat-area">
+      <div class="chat-header">
+        <button class="mobile-menu-btn" id="mobile-menu-btn">&#9776;</button>
+        <span class="chat-title" id="chat-title">Guardian</span>
+      </div>
+
+      <div class="messages-container" id="messages-container">
+        <div class="empty-state" id="empty-state">
+          <div class="empty-state-icon">&#9672;</div>
+          <div class="empty-state-title">Start a conversation</div>
+          <div class="empty-state-text">Send a message to Guardian. Your conversations are persisted and memory-augmented.</div>
+        </div>
+      </div>
+
+      <!-- Typing indicator -->
+      <div class="typing-indicator" id="typing-indicator">
+        <div class="message-avatar" style="background: var(--accent-dim); color: white;">G</div>
+        <div class="typing-dots">
+          <span class="typing-dot"></span>
+          <span class="typing-dot"></span>
+          <span class="typing-dot"></span>
+        </div>
+      </div>
+
+      <div class="input-area">
+        <div class="input-wrapper">
+          <textarea id="message-input" placeholder="Message Guardian..." rows="1"></textarea>
+          <button class="send-btn" id="send-btn" disabled title="Send message">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="22" y1="2" x2="11" y2="13"></line>
+              <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+            </svg>
+          </button>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/guardian/public/styles.css
+++ b/guardian/public/styles.css
@@ -1,0 +1,653 @@
+/* Guardian Chat UI — Dark theme */
+
+:root {
+  --bg-primary: #0f1117;
+  --bg-secondary: #161922;
+  --bg-tertiary: #1c1f2e;
+  --bg-hover: #232738;
+  --bg-active: #2a2e42;
+  --bg-user-msg: #2a2e42;
+  --bg-guardian-msg: #0d2d3a;
+  --border: #2a2e42;
+  --border-focus: #38bdf8;
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+  --accent: #22d3ee;
+  --accent-dim: #0e7490;
+  --accent-glow: rgba(34, 211, 238, 0.12);
+  --danger: #ef4444;
+  --success: #22c55e;
+  --radius: 8px;
+  --radius-lg: 12px;
+  --sidebar-width: 280px;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  --transition: 150ms ease;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  font-family: var(--font-sans);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ─── Auth Screen ─── */
+
+#auth-screen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: var(--bg-primary);
+}
+
+.auth-container {
+  width: 100%;
+  max-width: 400px;
+  padding: 2rem;
+}
+
+.auth-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.auth-logo {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 0.25rem;
+  letter-spacing: -0.02em;
+}
+
+.auth-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.auth-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+}
+
+.auth-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.auth-tab {
+  flex: 1;
+  padding: 0.75rem;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color var(--transition), border-color var(--transition);
+  font-family: var(--font-sans);
+}
+
+.auth-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.auth-tab:hover:not(.active) {
+  color: var(--text-primary);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-group label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.form-group input {
+  padding: 0.65rem 0.75rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-family: var(--font-sans);
+  outline: none;
+  transition: border-color var(--transition);
+}
+
+.form-group input:focus {
+  border-color: var(--border-focus);
+}
+
+.auth-btn {
+  padding: 0.7rem 1rem;
+  background: var(--accent-dim);
+  color: white;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  transition: background var(--transition);
+  margin-top: 0.25rem;
+}
+
+.auth-btn:hover {
+  background: var(--accent);
+  color: var(--bg-primary);
+}
+
+.auth-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.auth-error {
+  color: var(--danger);
+  font-size: 0.8rem;
+  text-align: center;
+  min-height: 1.2rem;
+}
+
+/* ─── Chat Layout ─── */
+
+#chat-screen {
+  display: none;
+  height: 100vh;
+}
+
+#chat-screen.visible {
+  display: flex;
+}
+
+/* ─── Sidebar ─── */
+
+.sidebar {
+  width: var(--sidebar-width);
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.sidebar-header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sidebar-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: -0.01em;
+}
+
+.new-chat-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1.1rem;
+  transition: all var(--transition);
+}
+
+.new-chat-btn:hover {
+  background: var(--bg-hover);
+  color: var(--accent);
+  border-color: var(--accent-dim);
+}
+
+.conversation-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.conversation-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.conversation-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.conversation-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.conversation-item {
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition);
+  margin-bottom: 2px;
+}
+
+.conversation-item:hover {
+  background: var(--bg-hover);
+}
+
+.conversation-item.active {
+  background: var(--bg-active);
+}
+
+.conversation-item-title {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.conversation-item-meta {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.sidebar-footer {
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.user-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.user-email {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 170px;
+}
+
+.logout-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  transition: all var(--transition);
+  font-family: var(--font-sans);
+}
+
+.logout-btn:hover {
+  color: var(--danger);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+/* ─── Chat Area ─── */
+
+.chat-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.chat-header {
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 52px;
+}
+
+.mobile-menu-btn {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.chat-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ─── Messages ─── */
+
+.messages-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.messages-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.messages-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.messages-container::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.message {
+  display: flex;
+  gap: 0.75rem;
+  max-width: 80%;
+  animation: messageIn 200ms ease-out;
+}
+
+@keyframes messageIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.message.user {
+  align-self: flex-end;
+  flex-direction: row-reverse;
+}
+
+.message.assistant {
+  align-self: flex-start;
+}
+
+.message-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.message.user .message-avatar {
+  background: var(--bg-active);
+  color: var(--text-secondary);
+}
+
+.message.assistant .message-avatar {
+  background: var(--accent-dim);
+  color: white;
+}
+
+.message-bubble {
+  padding: 0.65rem 0.9rem;
+  border-radius: var(--radius-lg);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message.user .message-bubble {
+  background: var(--bg-user-msg);
+  border-bottom-right-radius: 4px;
+}
+
+.message.assistant .message-bubble {
+  background: var(--bg-guardian-msg);
+  border: 1px solid rgba(34, 211, 238, 0.1);
+  border-bottom-left-radius: 4px;
+}
+
+/* ─── Typing Indicator ─── */
+
+.typing-indicator {
+  display: none;
+  align-self: flex-start;
+  gap: 0.75rem;
+  max-width: 80%;
+  padding: 0 0 0.5rem;
+}
+
+.typing-indicator.visible {
+  display: flex;
+}
+
+.typing-dots {
+  padding: 0.75rem 1rem;
+  background: var(--bg-guardian-msg);
+  border: 1px solid rgba(34, 211, 238, 0.1);
+  border-radius: var(--radius-lg);
+  border-bottom-left-radius: 4px;
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.typing-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: typingPulse 1.4s infinite ease-in-out;
+}
+
+.typing-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.typing-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes typingPulse {
+  0%, 60%, 100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  30% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ─── Empty State ─── */
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  text-align: center;
+}
+
+.empty-state-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  opacity: 0.6;
+}
+
+.empty-state-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--text-primary);
+}
+
+.empty-state-text {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  max-width: 360px;
+}
+
+/* ─── Input Area ─── */
+
+.input-area {
+  padding: 0.75rem 1.25rem 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.input-wrapper {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-end;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 0.5rem 0.5rem 0.5rem 0.85rem;
+  transition: border-color var(--transition);
+}
+
+.input-wrapper:focus-within {
+  border-color: var(--border-focus);
+}
+
+#message-input {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  resize: none;
+  outline: none;
+  max-height: 150px;
+  min-height: 24px;
+}
+
+#message-input::placeholder {
+  color: var(--text-muted);
+}
+
+.send-btn {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-dim);
+  border: none;
+  border-radius: var(--radius);
+  color: white;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--transition);
+}
+
+.send-btn:hover:not(:disabled) {
+  background: var(--accent);
+  color: var(--bg-primary);
+}
+
+.send-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.send-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* ─── Mobile Overlay ─── */
+
+.sidebar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 9;
+}
+
+/* ─── Responsive ─── */
+
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 10;
+    transform: translateX(-100%);
+    transition: transform 200ms ease;
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  .sidebar.open ~ .sidebar-overlay {
+    display: block;
+  }
+
+  .mobile-menu-btn {
+    display: block;
+  }
+
+  .message {
+    max-width: 90%;
+  }
+}

--- a/guardian/src/__tests__/config-api.test.ts
+++ b/guardian/src/__tests__/config-api.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { app } from '../app.js';
+
+describe('GET /api/config', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_ANON_KEY = 'test-anon-key-123';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns supabaseUrl and supabaseAnonKey from environment', async () => {
+    const res = await app.request('/api/config');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      supabaseUrl: 'https://test.supabase.co',
+      supabaseAnonKey: 'test-anon-key-123',
+    });
+  });
+
+  it('returns 500 when SUPABASE_URL is missing', async () => {
+    delete process.env.SUPABASE_URL;
+    const res = await app.request('/api/config');
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Server configuration incomplete' });
+  });
+
+  it('returns 500 when SUPABASE_ANON_KEY is missing', async () => {
+    delete process.env.SUPABASE_ANON_KEY;
+    const res = await app.request('/api/config');
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Server configuration incomplete' });
+  });
+});

--- a/guardian/src/app.ts
+++ b/guardian/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { serveStatic } from '@hono/node-server/serve-static';
 import { serve as serveInngest } from 'inngest/hono';
 import {
   verifySignature,
@@ -16,6 +17,21 @@ import { responderHandler } from './inngest/functions/responder.js';
 import { chatRouter, conversationsRouter } from './chat/router.js';
 
 export const app = new Hono();
+
+// Public config endpoint — exposes safe-to-share Supabase config for the frontend
+app.get('/api/config', (c) => {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return c.json({ error: 'Server configuration incomplete' }, 500);
+  }
+
+  return c.json({
+    supabaseUrl,
+    supabaseAnonKey,
+  });
+});
 
 // Chat API routes (authenticated)
 app.route('/api/chat', chatRouter);
@@ -127,3 +143,9 @@ app.post('/api/webhooks/github', async (c) => {
     return c.json({ error: 'Internal server error' }, 500);
   }
 });
+
+// Serve static files from public/ directory
+app.use('/*', serveStatic({ root: './public' }));
+
+// Fallback: serve index.html for root and unknown non-API paths (SPA-style)
+app.get('/', serveStatic({ root: './public', path: '/index.html' }));


### PR DESCRIPTION
## Summary

- **Web chat interface** (`public/index.html`, `styles.css`, `app.js`) — vanilla HTML/CSS/JS, no frameworks
- **Dark theme** with modern aesthetic (Discord meets Claude) — teal accent, chat bubbles, responsive sidebar
- **Full auth flow** — Supabase login/signup/logout via CDN client, session persistence
- **Conversation management** — list, create, switch conversations with relative timestamps
- **Chat messaging** — sends to `POST /api/chat`, displays Guardian responses with typing indicator
- **`GET /api/config`** endpoint — serves public Supabase URL + anon key to the frontend
- **Static file serving** via `@hono/node-server` `serveStatic` middleware
- **3 new tests** for `/api/config` (208 total, all passing)

### User flow
1. Open `http://localhost:3000` — see login/signup form
2. Sign up or log in with email + password
3. Type a message — Guardian responds with memory-augmented answer
4. Conversations persist in sidebar, switch between them
5. Mobile: hamburger menu toggles sidebar overlay

### UX details
- Enter to send, Shift+Enter for newline
- Auto-scroll to latest message
- Typing indicator (animated dots) while waiting for response
- Escape to close sidebar on mobile
- Textarea auto-resizes with content

## Test plan
- [x] Sacred Four: typecheck, lint, test (208/208), build — all pass
- [ ] Manual: open `http://localhost:3000`, sign up, send messages
- [ ] Manual: verify conversation list updates, switching works
- [ ] Manual: test on mobile viewport (responsive sidebar)
- [ ] Manual: verify logout clears state

🤖 Generated with [Claude Code](https://claude.com/claude-code)