### PR TITLE
fix(guardian): Use config GUARDIAN_REPO for memory retrieval

### DIFF
--- a/guardian/src/chat/response.ts
+++ b/guardian/src/chat/response.ts
@@ -3,10 +3,11 @@ import { getAnthropicClient } from '../llm/client.js';
 import { CHAT_SYSTEM_PROMPT, buildChatContextBlock } from '../llm/prompts.js';
 import { runRetriever } from '../agents/retriever.js';
 import { getMessagesByConversation } from '../db/queries.js';
+import { loadConfig } from '../config.js';
 import type { UserProfile, Message } from '../db/schema.js';
 
 /** Claude Sonnet model for chat responses. */
-const CHAT_MODEL = 'claude-sonnet-4-6-20250514';
+const CHAT_MODEL = 'claude-sonnet-4-20250514';
 
 /** Maximum conversation history messages to include in context. */
 const MAX_HISTORY_MESSAGES = 20;
@@ -14,8 +15,8 @@ const MAX_HISTORY_MESSAGES = 20;
 /** Maximum tokens for chat response. */
 const MAX_TOKENS = 1024;
 
-/** Default repo ID for memory retrieval. */
-const DEFAULT_REPO_ID = 'leonardrknight/ai-continuity-framework';
+/** Get repo ID from config. */
+const getRepoId = (): string => loadConfig().GUARDIAN_REPO;
 
 /**
  * Build the full system prompt with memory context injected.
@@ -64,7 +65,7 @@ export async function generateChatResponse(
   userId: string,
   repoId?: string,
 ): Promise<{ text: string; memoriesUsed: number }> {
-  const effectiveRepoId = repoId ?? DEFAULT_REPO_ID;
+  const effectiveRepoId = repoId ?? getRepoId();
 
   // Step 1: Get recent conversation history (before the current message)
   const history = await getMessagesByConversation(client, conversationId, MAX_HISTORY_MESSAGES);


### PR DESCRIPTION
## Problem

Memory retrieval was failing because the retriever used a hardcoded repo ID:
```typescript
const DEFAULT_REPO_ID = 'leonardrknight/ai-continuity-framework';
```

But memories were being stored with the configured `GUARDIAN_REPO` value (e.g., `amigo/guardian`).

## Solution

Use the config value instead of hardcoded default:
```typescript
const getRepoId = (): string => loadConfig().GUARDIAN_REPO;
```

## Also Fixed

- Model name: `claude-sonnet-4-6-20250514` → `claude-sonnet-4-20250514`

## Testing

After this fix:
```
Memories used: 7
Guardian remembers: Leo (CTO), Jeff (CEO), Carlos (COO/CFO)
```

---
*Amigo — testing Guardian, finding bugs, making PRs* 🤝