### PR TITLE
fix(guardian): Add user isolation to memory retrieval

### DIFF
--- a/guardian/src/agents/retriever.ts
+++ b/guardian/src/agents/retriever.ts
@@ -167,6 +167,7 @@ export async function runRetriever(
   client: SupabaseClient,
   query: string,
   repoId: string,
+  userId?: string,
   contributorId?: string,
 ): Promise<RetrievalResult> {
   const startTime = Date.now();
@@ -196,6 +197,7 @@ export async function runRetriever(
           query_embedding: embedding,
           query_text: query,
           filter_repo_id: repoId,
+          filter_user_id: userId,
           match_threshold: MATCH_THRESHOLD,
           match_count: CANDIDATE_COUNT,
         });
@@ -214,6 +216,7 @@ export async function runRetriever(
           query_embedding: Array.from({ length: 1536 }, () => 0),
           query_text: query,
           filter_repo_id: repoId,
+          filter_user_id: userId,
           match_threshold: MATCH_THRESHOLD,
           match_count: CANDIDATE_COUNT,
           semantic_weight: 0, // keyword only
@@ -238,6 +241,7 @@ export async function runRetriever(
         query_embedding: Array.from({ length: 1536 }, () => 0),
         query_text: query,
         filter_repo_id: repoId,
+        filter_user_id: userId,
         match_threshold: MATCH_THRESHOLD,
         match_count: CANDIDATE_COUNT,
         semantic_weight: 0,

--- a/guardian/src/chat/response.ts
+++ b/guardian/src/chat/response.ts
@@ -70,8 +70,8 @@ export async function generateChatResponse(
   // Step 1: Get recent conversation history (before the current message)
   const history = await getMessagesByConversation(client, conversationId, MAX_HISTORY_MESSAGES);
 
-  // Step 2: Retrieve relevant memories
-  const retrieval = await runRetriever(client, userMessage, effectiveRepoId, undefined);
+  // Step 2: Retrieve relevant memories (filtered by userId for isolation)
+  const retrieval = await runRetriever(client, userMessage, effectiveRepoId, userId);
 
   // Step 3: Build system prompt
   const systemPrompt = buildChatSystemPrompt(retrieval.memories, null);


### PR DESCRIPTION
## Security Fix

**CRITICAL:** Memory retrieval was returning ALL memories regardless of user, causing data leakage.

## Before (broken)
```
User 1 (Amigo): Teaches Guardian about Mi Amigos AI
User 2 (Test): Asks about Mi Amigos AI
Result: User 2 gets 10 memories ❌ (sees Amigo's data!)
```

## After (fixed)
```
User 1 (Amigo): Teaches Guardian about Mi Amigos AI
User 2 (Test): Asks about Mi Amigos AI  
Result: User 2 gets 0 memories ✅ (properly isolated!)
```

## Changes

### `guardian/src/agents/retriever.ts`
- Added `userId` parameter to `runRetriever()`
- Pass `filter_user_id: userId` to all three `matchMemories()` calls

### `guardian/src/chat/response.ts`
- Pass `userId` from chat handler to `runRetriever()`

## Testing

Ran isolation test with two users:
1. Amigo taught Guardian about Mi Amigos AI founders
2. Test user asked about founders → got 0 memories (correct!)
3. Test user taught Guardian about purple/Acme
4. Amigo asked about purple/Acme → got 0 memories (correct!)

Fixes #35

---
*Amigo — testing Guardian, finding & fixing bugs* 🤝